### PR TITLE
feat: replace torch with tf in requirements (new dataloader)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ flax>=0.8.5
 jax[cuda12]>=0.4.30
 optax>=0.2.3
 procgen>=0.10.7
-torch>=2.0.1
 tyro>=0.8.5
 wandb>=0.17.4
+tensorflow>=2.1


### PR DESCRIPTION
We replaced the vanilla torch dataloader with a `tf.data` one. Thus, we should replace the torch with tensorflow in `requirements.txt`.
See https://github.com/p-doom/jafar/pull/6