### PR TITLE
feat: DP in tokenizer, lam, dynamics via JAX autoparallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ python generate_dataset.py --num_episodes 10000
 
 Note: this is a large dataset (around 100GB) and may take a while to generate.
 
+For performant distributed training, we additionally preprocess the dataset into `TFRecord`s:
+
+```bash
+python preprocess_dataset.py
+```
+
 <h2 name="train" id="train">Quick Start 🚀 </h2>
 
 Genie has three components: a [video tokenizer](models/tokenizer.py), a [latent action model](models/lam.py), and a [dynamics model](models/dynamics.py). Each of these components are trained separately, however, the dynamics model requires a pre-trained video tokenizer and latent action model.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ flax>=0.8.5
 jax[cuda12]>=0.4.30
 optax>=0.2.3
 procgen>=0.10.7
-torch>=2.0.1
 tyro>=0.8.5
 wandb>=0.17.4
+tensorflow>=2.1

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -27,7 +27,7 @@ class Args:
     seq_len: int = 16
     image_channels: int = 3
     image_resolution: int = 64
-    data_dir: str = "data/coinrun_episodes"
+    data_dir: str = "data_tfrecords/coinrun"
     # Optimization
     batch_size: int = 36
     min_lr: float = 3e-6

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -156,7 +156,14 @@ if __name__ == "__main__":
     train_state = TrainState.create(apply_fn=genie.apply, params=init_params, tx=tx)
 
     # --- TRAIN LOOP ---
-    dataloader = get_dataloader(args.data_dir, args.seq_len, args.batch_size)
+    tfrecord_files = [
+        os.path.join(args.data_dir, x)
+        for x in os.listdir(args.data_dir)
+        if x.endswith(".tfrecord")
+    ]
+    dataloader = get_dataloader(
+        tfrecord_files, args.seq_len, args.batch_size, *image_shape
+    )
     step = 0
     while step < args.num_steps:
         for videos in dataloader:

--- a/train_lam.py
+++ b/train_lam.py
@@ -29,7 +29,7 @@ class Args:
     seq_len: int = 16
     image_channels: int = 3
     image_resolution: int = 64
-    data_dir: str = "data/coinrun_episodes"
+    data_dir: str = "data_tfrecords/coinrun"
     checkpoint: str = ""
     # Optimization
     batch_size: int = 36

--- a/train_lam.py
+++ b/train_lam.py
@@ -163,7 +163,15 @@ if __name__ == "__main__":
     train_state = TrainState.create(apply_fn=lam.apply, params=init_params, tx=tx)
 
     # --- TRAIN LOOP ---
-    dataloader = get_dataloader(args.data_dir, args.seq_len, args.batch_size)
+    tfrecord_files = [
+        os.path.join(args.data_dir, x)
+        for x in os.listdir(args.data_dir)
+        if x.endswith(".tfrecord")
+    ]
+    dataloader = get_dataloader(
+        tfrecord_files, args.seq_len, args.batch_size, *image_shape
+    )
+    print(f"Starting training from step {step}...")
     while step < args.num_steps:
         for videos in dataloader:
             # --- Train step ---

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -5,6 +5,8 @@ import time
 import einops
 from flax.training import orbax_utils
 from flax.training.train_state import TrainState
+from jax.sharding import Mesh, PartitionSpec, NamedSharding
+from jax.experimental.mesh_utils import create_device_mesh
 import optax
 import orbax
 from orbax.checkpoint import PyTreeCheckpointer
@@ -112,6 +114,17 @@ def train_step(state, inputs):
 
 
 if __name__ == "__main__":
+    num_devices = jax.device_count()
+    if num_devices == 0:
+        raise ValueError("No JAX devices found.")
+    print(f"Running on {num_devices} devices.")
+
+    if args.batch_size % num_devices != 0:
+        raise ValueError(
+            f"Global batch size {args.batch_size} must be divisible by "
+            f"number of devices {num_devices}."
+        )
+
     rng = jax.random.PRNGKey(args.seed)
     if args.log:
         wandb.init(entity=args.entity, project=args.project, group="debug", config=args)
@@ -152,6 +165,14 @@ if __name__ == "__main__":
     )
     tx = optax.adamw(learning_rate=lr_schedule, b1=0.9, b2=0.9, weight_decay=1e-4)
     train_state = TrainState.create(apply_fn=tokenizer.apply, params=init_params, tx=tx)
+    
+    # FIXME: switch to create_hybrid_device_mesh for runs spanning multiple nodes
+    device_mesh_arr = create_device_mesh((num_devices,))
+    mesh = Mesh(devices=device_mesh_arr, axis_names=('data',))
+
+    replicated_sharding = NamedSharding(mesh, PartitionSpec())
+    train_state = jax.device_put(train_state, replicated_sharding)
+
 
     # --- TRAIN LOOP ---
     tfrecord_files = [
@@ -167,6 +188,10 @@ if __name__ == "__main__":
         for videos in dataloader:
             # --- Train step ---
             rng, _rng = jax.random.split(rng)
+            
+            videos_sharding = NamedSharding(mesh, PartitionSpec('data', None, None, None, None))
+            videos = jax.device_put(videos, videos_sharding)
+            
             inputs = dict(videos=videos, rng=_rng)
             train_state, loss, recon, metrics = train_step(train_state, inputs)
             print(f"Step {step}, loss: {loss}")

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -154,7 +154,15 @@ if __name__ == "__main__":
     train_state = TrainState.create(apply_fn=tokenizer.apply, params=init_params, tx=tx)
 
     # --- TRAIN LOOP ---
-    dataloader = get_dataloader(args.data_dir, args.seq_len, args.batch_size)
+    tfrecord_files = [
+        os.path.join(args.data_dir, x)
+        for x in os.listdir(args.data_dir)
+        if x.endswith(".tfrecord")
+    ]
+    dataloader = get_dataloader(
+        tfrecord_files, args.seq_len, args.batch_size, *image_shape
+    )
+    print(f"Starting training from step {step}...")
     while step < args.num_steps:
         for videos in dataloader:
             # --- Train step ---

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -29,7 +29,7 @@ class Args:
     seq_len: int = 16
     image_channels: int = 3
     image_resolution: int = 64
-    data_dir: str = "data/coinrun_episodes"
+    data_dir: str = "data_tfrecords/coinrun"
     checkpoint: str = ""
     # Optimization
     vq_beta: float = 0.25

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -1,36 +1,110 @@
-from pathlib import Path
+import functools
 
-import jax.numpy as jnp
-import numpy as np
-from torch.utils.data import Dataset, DataLoader
+import tensorflow as tf
 
 
-class VideoDataset(Dataset):
-    def __init__(self, data_dir, seq_len):
-        self.data_dir = Path(data_dir)
-        self.seq_len = seq_len
-        self.metadata = np.load(self.data_dir / "metadata.npy", allow_pickle=True)
+# --- TensorFlow function for processing: slicing, normalization ---
+def _tf_process_episode(episode_tensor, seq_len, image_h, image_w, image_c):
+    """
+    Processes a raw episode tensor in TensorFlow.
+    Takes a full episode, extracts a random sequence, and normalizes it.
+    Args:
+        episode_tensor: A TensorFlow tensor representing a full video episode.
+                        Expected shape: (dynamic_length, image_h, image_w, image_c)
+                        Expected dtype: e.g., tf.uint8 (raw pixel values)
+        seq_len: The desired length of the sub-sequence to extract.
+        image_h: The height of each frame.
+        image_w: The width of each frame.
+        image_c: The number of channels in each frame.
+    Returns:
+        A TensorFlow tensor representing the processed video sequence.
+        Shape: (seq_len, image_h, image_w, image_c)
+        Dtype: tf.float32 (normalized pixel values)
+    """
+    current_episode_len = tf.shape(episode_tensor)[0]
 
-    def __len__(self):
-        return len(self.metadata)
+    max_start_idx = current_episode_len - seq_len
 
-    def __getitem__(self, idx):
-        episode = np.load(self.metadata[idx]["path"])
-        start_idx = np.random.randint(0, len(episode) - self.seq_len + 1)
-        seq = episode[start_idx : start_idx + self.seq_len]
-        return seq.astype(np.float32) / 255.0
-
-
-def collate_fn(batch):
-    """Convert batch of numpy arrays to JAX array"""
-    return jnp.array(np.stack(batch))
-
-
-def get_dataloader(data_dir, seq_len, batch_size):
-    dataset = VideoDataset(data_dir, seq_len)
-    return DataLoader(
-        dataset,
-        batch_size=batch_size,
-        shuffle=True,
-        collate_fn=collate_fn,
+    start_idx = tf.random.uniform(
+        shape=(), minval=0, maxval=max_start_idx + 1, dtype=tf.int32
     )
+
+    seq = episode_tensor[start_idx : start_idx + seq_len]
+
+    seq = tf.cast(seq, tf.float32) / 255.0
+
+    # Ensure the final shape is statically known for batching.
+    # tf.reshape is robust, but tf.ensure_shape or set_shape can also be used if confident.
+    processed_sequence = tf.reshape(seq, [seq_len, image_h, image_w, image_c])
+
+    return processed_sequence
+
+
+def _parse_tfrecord_fn(example_proto, image_h, image_w, image_c):
+    feature_description = {
+        "height": tf.io.FixedLenFeature([], tf.int64),
+        "width": tf.io.FixedLenFeature([], tf.int64),
+        "channels": tf.io.FixedLenFeature([], tf.int64),
+        "sequence_length": tf.io.FixedLenFeature([], tf.int64),
+        "raw_video": tf.io.FixedLenFeature([], tf.string),
+    }
+    example = tf.io.parse_single_example(example_proto, feature_description)
+
+    video_shape = (example["sequence_length"], image_h, image_w, image_c)
+
+    episode_tensor = tf.io.decode_raw(example["raw_video"], out_type=tf.uint8)
+    episode_tensor = tf.reshape(episode_tensor, video_shape)
+
+    episode_tensor = tf.ensure_shape(episode_tensor, [None, image_h, image_w, image_c])
+    return episode_tensor
+
+
+def get_dataloader(
+    tfrecord_paths: list[str],  # List of TFRecord file paths
+    seq_len: int,
+    global_batch_size: int,
+    image_h: int,
+    image_w: int,
+    image_c: int,
+    shuffle_buffer_size: int = 1000,
+    num_parallel_calls: int = tf.data.AUTOTUNE,
+    cache_processed_data: bool = True,
+    seed: int = 42,
+):
+    """
+    Creates a tf.data.Dataset pipeline from TFRecord files.
+    """
+    if not tfrecord_paths:
+        raise ValueError("tfrecord_paths list cannot be empty.")
+
+    dataset = tf.data.TFRecordDataset(
+        tfrecord_paths, num_parallel_reads=tf.data.AUTOTUNE
+    )
+
+    # (f.srambical) NOTE: For TFRecords, it's often good to have a large shuffle buffer.
+    if shuffle_buffer_size > 0:
+        dataset = dataset.shuffle(
+            buffer_size=shuffle_buffer_size, seed=seed, reshuffle_each_iteration=True
+        )
+
+    parse_fn = functools.partial(
+        _parse_tfrecord_fn, image_h=image_h, image_w=image_w, image_c=image_c
+    )
+    dataset = dataset.map(parse_fn, num_parallel_calls=num_parallel_calls)
+
+    tf_process_fn = functools.partial(
+        _tf_process_episode,
+        seq_len=seq_len,
+        image_h=image_h,
+        image_w=image_w,
+        image_c=image_c,
+    )
+    dataset = dataset.map(tf_process_fn, num_parallel_calls=num_parallel_calls)
+
+    dataset = dataset.cache() if cache_processed_data else dataset
+
+    dataset = dataset.repeat(None)
+    dataset = dataset.batch(global_batch_size, drop_remainder=True)
+    dataset = dataset.prefetch(tf.data.AUTOTUNE)
+
+    return dataset.as_numpy_iterator()

--- a/utils/preprocess_dataset.py
+++ b/utils/preprocess_dataset.py
@@ -1,0 +1,96 @@
+import tensorflow as tf
+import numpy as np
+import logging
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO)
+
+
+def _bytes_feature(value):
+    if isinstance(value, type(tf.constant(0))):
+        value = value.numpy()
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+
+def _int64_feature(value):
+    return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
+
+
+def create_tfrecord_example(episode_numpy_array):
+    feature = {
+        "height": _int64_feature(episode_numpy_array.shape[1]),
+        "width": _int64_feature(episode_numpy_array.shape[2]),
+        "channels": _int64_feature(episode_numpy_array.shape[3]),
+        "sequence_length": _int64_feature(episode_numpy_array.shape[0]),
+        "raw_video": _bytes_feature(episode_numpy_array.tobytes()),
+    }
+    return tf.train.Example(features=tf.train.Features(feature=feature))
+
+
+def main_preprocess(data_dir_str, output_dir_str, num_shards):
+    data_dir = Path(data_dir_str)
+    output_dir = Path(output_dir_str)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata = np.load(data_dir / "metadata.npy", allow_pickle=True)
+    episode_source_paths = [Path(item["path"]) for item in metadata]
+    num_total_episodes = len(episode_source_paths)
+
+    if num_shards <= 0:
+        raise ValueError("num_shards must be positive.")
+    if num_shards > num_total_episodes:
+        logging.warning(
+            f"Warning: num_shards ({num_shards}) is greater than total episodes ({num_total_episodes}). "
+            f"Setting num_shards to {num_total_episodes}."
+        )
+        num_shards = num_total_episodes
+
+    logging.info(
+        f"Preparing to write {num_total_episodes} episodes to {num_shards} TFRecord shards in {output_dir}..."
+    )
+
+    output_filenames = [
+        str(output_dir / f"shard-{i:05d}-of-{num_shards:05d}.tfrecord")
+        for i in range(num_shards)
+    ]
+    writers = [tf.io.TFRecordWriter(filename) for filename in output_filenames]
+
+    writer_idx_for_episode = 0
+    try:
+        for i, npy_path in enumerate(episode_source_paths):
+            if i % 100 == 0 and i > 0:
+                logging.info(f"  Processed {i}/{num_total_episodes} episodes...")
+            try:
+                episode_data = np.load(npy_path)
+                tf_example = create_tfrecord_example(episode_data)
+
+                current_writer = writers[writer_idx_for_episode]
+                current_writer.write(tf_example.SerializeToString())
+
+                writer_idx_for_episode = (writer_idx_for_episode + 1) % num_shards
+
+            except Exception as e:
+                logging.error(f"Skipping {npy_path} due to error: {e}")
+    finally:
+        for writer in writers:
+            writer.close()
+        logging.info(
+            f"TFRecord sharding complete. {num_shards} shards written to {output_dir}."
+        )
+        logging.info("Generated shard files:")
+        for fname in output_filenames:
+            logging.info(f"  {fname}")
+
+
+if __name__ == "__main__":
+    source_data_dir = "data/coinrun_episodes"
+    output_tfrecords_dir = "data_tfrecords"
+    NUM_SHARDS = 50
+
+    if (
+        not Path(source_data_dir).exists()
+        or not (Path(source_data_dir) / "metadata.npy").exists()
+    ):
+        logging.error(f"Please generate data in '{source_data_dir}' first.")
+    else:
+        main_preprocess(source_data_dir, output_tfrecords_dir, NUM_SHARDS)


### PR DESCRIPTION
This PR supersedes the training parallelism part of https://github.com/p-doom/jafar/pull/6. The `tf.data` part of https://github.com/p-doom/jafar/pull/6 is now at https://github.com/p-doom/jafar/pull/9.

Unlike https://github.com/p-doom/jafar/pull/6, we now use JAX' autoparallelism capabilities using `NamedSharding` and `PartitionSpec` and let `jax.jit` handle inserting communication collectives wherever necessary, instead of 'hardcoding' `pamps`.