### PR TITLE
fix: seeded episode sampling for reproducibility

### DIFF
--- a/tests/data/generate_dummy_tfrecord.py
+++ b/tests/data/generate_dummy_tfrecord.py
@@ -1,6 +1,15 @@
+import tyro
 import tensorflow as tf
 import numpy as np
 from pathlib import Path
+from dataclasses import dataclass
+
+@dataclass
+class Args:
+    data_dir: str = "data_tfrecords/dummy"
+    num_episodes: int = 5
+    episode_length: int = 16
+
 
 
 def _bytes_feature(value):
@@ -28,7 +37,7 @@ def create_tfrecord_example(episode_numpy_array):
 
 
 def generate_dummy_tfrecord(
-    output_path, num_episodes=5, episode_length=16, height=64, width=64, channels=3
+    output_path, num_episodes=5, episode_length=16, height=90, width=160, channels=3
 ):
     """Generates a dummy TFRecord file with synthetic video data."""
     print(f"Generating dummy TFRecord file at {output_path}")
@@ -44,8 +53,9 @@ def generate_dummy_tfrecord(
 
 
 if __name__ == "__main__":
-    temp_dir = Path("/tmp/jafar_test_data")
+    args = tyro.cli(Args)
+    temp_dir = Path(args.data_dir)
     temp_dir.mkdir(parents=True, exist_ok=True)
     dummy_file = temp_dir / "dummy_test_shard.tfrecord"
-    generate_dummy_tfrecord(dummy_file)
+    generate_dummy_tfrecord(dummy_file, num_episodes=args.num_episodes, episode_length=args.episode_length)
     print(f"Generated dummy file: {dummy_file}")

--- a/tests/data/generate_dummy_tfrecord.py
+++ b/tests/data/generate_dummy_tfrecord.py
@@ -1,0 +1,51 @@
+import tensorflow as tf
+import numpy as np
+from pathlib import Path
+
+
+def _bytes_feature(value):
+    """Returns a bytes_list from a string / byte."""
+    if isinstance(value, type(tf.constant(0))):
+        value = value.numpy()  # BytesList won't unpack a string from an EagerTensor.
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+
+def _int64_feature(value):
+    """Returns an int64_list from a bool / enum / int / uint."""
+    return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
+
+
+def create_tfrecord_example(episode_numpy_array):
+    """Creates a TFRecord example from a numpy array video."""
+    feature = {
+        "height": _int64_feature(episode_numpy_array.shape[1]),
+        "width": _int64_feature(episode_numpy_array.shape[2]),
+        "channels": _int64_feature(episode_numpy_array.shape[3]),
+        "sequence_length": _int64_feature(episode_numpy_array.shape[0]),
+        "raw_video": _bytes_feature(episode_numpy_array.tobytes()),
+    }
+    return tf.train.Example(features=tf.train.Features(feature=feature))
+
+
+def generate_dummy_tfrecord(
+    output_path, num_episodes=5, episode_length=16, height=64, width=64, channels=3
+):
+    """Generates a dummy TFRecord file with synthetic video data."""
+    print(f"Generating dummy TFRecord file at {output_path}")
+    with tf.io.TFRecordWriter(str(output_path)) as writer:
+        for i in range(num_episodes):
+            np.random.seed(i)  # Seed per episode for some variation, but deterministic
+            dummy_video = np.random.randint(
+                0, 256, size=(episode_length, height, width, channels), dtype=np.uint8
+            )
+            tf_example = create_tfrecord_example(dummy_video)
+            writer.write(tf_example.SerializeToString())
+    print("Dummy TFRecord generation complete.")
+
+
+if __name__ == "__main__":
+    temp_dir = Path("/tmp/jafar_test_data")
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    dummy_file = temp_dir / "dummy_test_shard.tfrecord"
+    generate_dummy_tfrecord(dummy_file)
+    print(f"Generated dummy file: {dummy_file}")

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,0 +1,68 @@
+import unittest
+import numpy as np
+import tensorflow as tf
+import tempfile
+from pathlib import Path
+
+from utils.dataloader import get_dataloader
+from tests.data.generate_dummy_tfrecord import generate_dummy_tfrecord
+
+
+class DataloaderReproducibilityTest(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self._temp_dir_manager = tempfile.TemporaryDirectory()
+        self.test_data_dir = Path(self._temp_dir_manager.name)
+        self.addCleanup(self._temp_dir_manager.cleanup)
+        self.dummy_tfrecord_path = self.test_data_dir / "dummy_test_shard.tfrecord"
+
+        self.num_episodes = 5
+        self.episode_length = 16
+        self.image_height = 64
+        self.image_width = 64
+        self.image_channels = 3
+        generate_dummy_tfrecord(
+            self.dummy_tfrecord_path,
+            num_episodes=self.num_episodes,
+            episode_length=self.episode_length,
+            height=self.image_height,
+            width=self.image_width,
+            channels=self.image_channels,
+        )
+        self.tfrecord_files = [str(self.dummy_tfrecord_path)]
+
+        self.fixed_seed = 42
+
+    def test_dataloader_yields_reproducible_batches(self):
+        seq_len = 8
+        batch_size = 2
+
+        dataloader1 = get_dataloader(
+            self.tfrecord_files,
+            seq_len,
+            batch_size,
+            self.image_height,
+            self.image_width,
+            self.image_channels,
+            seed=self.fixed_seed,
+        )
+        batches1 = [next(dataloader1) for _ in range(3)]
+
+        dataloader2 = get_dataloader(
+            self.tfrecord_files,
+            seq_len,
+            batch_size,
+            self.image_height,
+            self.image_width,
+            self.image_channels,
+            seed=self.fixed_seed,
+        )
+        batches2 = [next(dataloader2) for _ in range(3)]
+
+        for i, (b1, b2) in enumerate(zip(batches1, batches2)):
+            np.testing.assert_array_equal(b1, b2, err_msg=f"Batch {i} is not reproducible")  # type: ignore
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tokenizer_reproducibility.py
+++ b/tests/test_tokenizer_reproducibility.py
@@ -1,0 +1,538 @@
+import unittest
+import jax
+import numpy as np
+
+from models.tokenizer import TokenizerVQVAE
+from utils.nn import STTransformer, VectorQuantizer, PositionalEncoding, STBlock
+from utils.preprocess import patchify, unpatchify
+from train_tokenizer import create_training_functions
+
+
+class TokenizerReproducibilityTest(unittest.TestCase):
+    """Test reproducibility of tokenizer components and full model."""
+
+    def setUp(self):
+        super().setUp()
+        self.seed = 42
+        self.rng = jax.random.PRNGKey(self.seed)
+
+        self.batch_size = 1
+        self.seq_len = 4
+        self.image_height = 32
+        self.image_width = 32
+        self.image_channels = 3
+        self.patch_size = 4
+        self.model_dim = 64
+        self.latent_dim = 16
+        self.num_latents = 64
+        self.num_blocks = 1
+        self.num_heads = 2
+        self.dropout = 0.1
+        self.codebook_dropout = 0.01
+
+        self.rng, input_rng = jax.random.split(self.rng)
+        self.test_videos = jax.random.uniform(
+            input_rng,
+            (
+                self.batch_size,
+                self.seq_len,
+                self.image_height,
+                self.image_width,
+                self.image_channels,
+            ),
+        )
+
+    def test_positional_encoding_reproducibility(self):
+        """Test that positional encoding is deterministic."""
+        dim = 64
+        max_len = 100
+
+        pe1 = PositionalEncoding(dim, max_len)
+        pe2 = PositionalEncoding(dim, max_len)
+
+        rng1, rng2 = jax.random.split(self.rng)
+        x = jax.random.uniform(rng1, (2, 3, 50, dim))
+
+        params1 = pe1.init(rng1, x)
+        params2 = pe2.init(rng2, x)
+
+        output1 = pe1.apply(params1, x)
+        output2 = pe2.apply(params2, x)
+
+        np.testing.assert_array_equal(output1, output2)
+
+    def test_st_block_reproducibility(self):
+        """Test that STBlock is reproducible."""
+        dim = 64
+        num_heads = 4
+        dropout = 0.1
+
+        block1 = STBlock(dim, num_heads, dropout)
+        block2 = STBlock(dim, num_heads, dropout)
+
+        x = jax.random.uniform(self.rng, (2, 3, 16, dim))
+
+        params1 = block1.init(self.rng, x)
+        params2 = block2.init(self.rng, x)
+
+        rng_dropout = jax.random.PRNGKey(123)
+        output1 = block1.apply(params1, x, rngs={"dropout": rng_dropout})
+        output2 = block2.apply(params2, x, rngs={"dropout": rng_dropout})
+
+        np.testing.assert_array_equal(output1, output2)
+
+    def test_st_block_forward_pass_reproducibility(self):
+        """Test that STBlock forward pass is reproducible across multiple calls."""
+        dim = 64
+        num_heads = 4
+        dropout = 0.1
+
+        block = STBlock(dim, num_heads, dropout)
+
+        rng = jax.random.PRNGKey(self.seed)
+        x = jax.random.uniform(rng, (2, 3, 16, dim))
+        params = block.init(rng, x)
+
+        rng_dropout = jax.random.PRNGKey(123)
+        outputs = []
+        for _ in range(3):
+            output = block.apply(params, x, rngs={"dropout": rng_dropout})
+            outputs.append(output)
+
+        for i in range(1, len(outputs)):
+            np.testing.assert_array_equal(outputs[0], outputs[i])
+
+    def test_st_transformer_reproducibility(self):
+        """Test that STTransformer is reproducible."""
+        model_dim = 64
+        out_dim = 32
+        num_blocks = 2
+        num_heads = 4
+        dropout = 0.1
+
+        transformer1 = STTransformer(model_dim, out_dim, num_blocks, num_heads, dropout)
+        transformer2 = STTransformer(model_dim, out_dim, num_blocks, num_heads, dropout)
+
+        x = jax.random.uniform(self.rng, (2, 3, 16, 48))
+
+        params1 = transformer1.init(self.rng, x)
+        params2 = transformer2.init(self.rng, x)
+
+        rng_dropout = jax.random.PRNGKey(123)
+        output1 = transformer1.apply(params1, x, rngs={"dropout": rng_dropout})
+        output2 = transformer2.apply(params2, x, rngs={"dropout": rng_dropout})
+
+        np.testing.assert_array_equal(output1, output2)
+
+    def test_vector_quantizer_reproducibility(self):
+        """Test that VectorQuantizer is reproducible."""
+        latent_dim = 32
+        num_latents = 256
+        dropout = 0.01
+
+        vq1 = VectorQuantizer(latent_dim, num_latents, dropout)
+        vq2 = VectorQuantizer(latent_dim, num_latents, dropout)
+
+        x = jax.random.uniform(self.rng, (100, latent_dim))
+
+        params1 = vq1.init(self.rng, x, training=True)
+        params2 = vq2.init(self.rng, x, training=True)
+
+        rng_dropout = jax.random.PRNGKey(123)
+        output1 = vq1.apply(params1, x, training=True, rngs={"dropout": rng_dropout})
+        output2 = vq2.apply(params2, x, training=True, rngs={"dropout": rng_dropout})
+
+        for o1, o2 in zip(output1, output2):
+            np.testing.assert_array_equal(o1, o2)
+
+    def test_vector_quantizer_codebook_initialization_reproducibility(self):
+        """Test that VectorQuantizer codebook initialization is reproducible."""
+        latent_dim = 32
+        num_latents = 256
+        dropout = 0.01
+
+        rng = jax.random.PRNGKey(self.seed)
+        codebooks = []
+        for i in range(3):
+            vq = VectorQuantizer(latent_dim, num_latents, dropout)
+            x = jax.random.uniform(rng, (100, latent_dim))
+            params = vq.init(rng, x, training=True)
+            codebook = params["params"]["codebook"]
+            codebooks.append(codebook)
+
+        for i in range(1, len(codebooks)):
+            np.testing.assert_array_equal(codebooks[0], codebooks[i])
+
+    def test_patchify_unpatchify_reproducibility(self):
+        """Test that patchify/unpatchify operations are deterministic."""
+        videos = self.test_videos
+        patch_size = self.patch_size
+
+        patches1 = patchify(videos, patch_size)
+        patches2 = patchify(videos, patch_size)
+
+        np.testing.assert_array_equal(patches1, patches2)
+
+        H, W = videos.shape[2:4]
+        recon1 = unpatchify(patches1, patch_size, H, W)
+        recon2 = unpatchify(patches2, patch_size, H, W)
+
+        np.testing.assert_array_equal(recon1, recon2)
+
+    def test_tokenizer_vq_encode_reproducibility(self):
+        """Test that tokenizer vq_encode is reproducible."""
+        tokenizer1 = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=self.dropout,
+            codebook_dropout=self.codebook_dropout,
+        )
+        tokenizer2 = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=self.dropout,
+            codebook_dropout=self.codebook_dropout,
+        )
+
+        params1 = tokenizer1.init(self.rng, {"videos": self.test_videos})
+        params2 = tokenizer2.init(self.rng, {"videos": self.test_videos})
+
+        rng_dropout = jax.random.PRNGKey(123)
+        output1 = tokenizer1.apply(
+            params1,
+            self.test_videos,
+            method=tokenizer1.vq_encode,
+            training=True,
+            rngs={"dropout": rng_dropout},
+        )
+        output2 = tokenizer2.apply(
+            params2,
+            self.test_videos,
+            method=tokenizer2.vq_encode,
+            training=True,
+            rngs={"dropout": rng_dropout},
+        )
+
+        for key in output1.keys():
+            np.testing.assert_array_equal(output1[key], output2[key])
+
+    def test_full_tokenizer_reproducibility(self):
+        """Test that full tokenizer forward pass is reproducible."""
+        tokenizer1 = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=self.dropout,
+            codebook_dropout=self.codebook_dropout,
+        )
+        tokenizer2 = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=self.dropout,
+            codebook_dropout=self.codebook_dropout,
+        )
+
+        params1 = tokenizer1.init(self.rng, {"videos": self.test_videos})
+        params2 = tokenizer2.init(self.rng, {"videos": self.test_videos})
+
+        rng_dropout = jax.random.PRNGKey(123)
+        output1 = tokenizer1.apply(
+            params1,
+            {"videos": self.test_videos},
+            training=True,
+            rngs={"dropout": rng_dropout},
+        )
+        output2 = tokenizer2.apply(
+            params2,
+            {"videos": self.test_videos},
+            training=True,
+            rngs={"dropout": rng_dropout},
+        )
+
+        for key in output1.keys():
+            np.testing.assert_array_equal(output1[key], output2[key])
+
+    def test_tokenizer_loss_reproducibility(self):
+        """Test that tokenizer loss computation is reproducible."""
+
+        class MockArgs:
+            def __init__(self):
+                self.vq_beta = 0.25
+                self.num_latents = 64
+                self.log_gradients = False
+
+        args = MockArgs()
+
+        tokenizer_loss_fn, _ = create_training_functions(args)
+
+        tokenizer = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=self.dropout,
+            codebook_dropout=self.codebook_dropout,
+        )
+
+        params1 = tokenizer.init(self.rng, {"videos": self.test_videos})
+        params2 = tokenizer.init(self.rng, {"videos": self.test_videos})
+
+        rng_input = jax.random.PRNGKey(456)
+        inputs = {"videos": self.test_videos, "rng": rng_input}
+
+        class MockState:
+            def __init__(self, apply_fn):
+                self.apply_fn = apply_fn
+
+        state1 = MockState(tokenizer.apply)
+        state2 = MockState(tokenizer.apply)
+
+        loss1, (recon1, metrics1) = tokenizer_loss_fn(params1, state1, inputs)
+        loss2, (recon2, metrics2) = tokenizer_loss_fn(params2, state2, inputs)
+
+        np.testing.assert_array_equal(loss1, loss2)
+        np.testing.assert_array_equal(recon1, recon2)
+        for key in metrics1.keys():
+            np.testing.assert_array_equal(metrics1[key], metrics2[key])
+
+    def test_tokenizer_gradient_reproducibility(self):
+        """Test that gradients are reproducible."""
+
+        class MockArgs:
+            def __init__(self):
+                self.vq_beta = 0.25
+                self.num_latents = 64
+                self.log_gradients = False
+
+        args = MockArgs()
+
+        tokenizer_loss_fn, _ = create_training_functions(args)
+
+        tokenizer = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=self.dropout,
+            codebook_dropout=self.codebook_dropout,
+        )
+
+        rng = jax.random.PRNGKey(self.seed)
+        test_videos = jax.random.uniform(
+            rng,
+            (
+                self.batch_size,
+                self.seq_len,
+                self.image_height,
+                self.image_width,
+                self.image_channels,
+            ),
+        )
+        params = tokenizer.init(rng, {"videos": test_videos})
+
+        rng_input = jax.random.PRNGKey(456)
+        inputs = {"videos": test_videos, "rng": rng_input}
+
+        class MockState:
+            def __init__(self, apply_fn):
+                self.apply_fn = apply_fn
+
+        state = MockState(tokenizer.apply)
+
+        grad_fn = jax.value_and_grad(tokenizer_loss_fn, has_aux=True, allow_int=True)
+        (loss1, (recon1, metrics1)), grads1 = grad_fn(params, state, inputs)
+        (loss2, (recon2, metrics2)), grads2 = grad_fn(params, state, inputs)
+
+        np.testing.assert_array_equal(loss1, loss2)
+        np.testing.assert_array_equal(recon1, recon2)
+        for key in metrics1.keys():
+            np.testing.assert_array_equal(metrics1[key], metrics2[key])
+
+        jax.tree.map(lambda x, y: np.testing.assert_array_equal(x, y), grads1, grads2)
+
+    def test_training_step_reproducibility(self):
+        """Test that training step is reproducible."""
+
+        class MockArgs:
+            def __init__(self):
+                self.vq_beta = 0.25
+                self.num_latents = 64
+                self.log_gradients = False
+
+        args = MockArgs()
+
+        _, train_step = create_training_functions(args)
+
+        tokenizer = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=self.dropout,
+            codebook_dropout=self.codebook_dropout,
+        )
+
+        params1 = tokenizer.init(self.rng, {"videos": self.test_videos})
+        params2 = tokenizer.init(self.rng, {"videos": self.test_videos})
+
+        import optax
+
+        tx = optax.adamw(learning_rate=1e-4)
+        from flax.training.train_state import TrainState
+
+        state1 = TrainState.create(apply_fn=tokenizer.apply, params=params1, tx=tx)
+        state2 = TrainState.create(apply_fn=tokenizer.apply, params=params2, tx=tx)
+
+        rng_input = jax.random.PRNGKey(456)
+        inputs = {"videos": self.test_videos, "rng": rng_input}
+
+        _, loss1, recon1, metrics1 = train_step(state1, inputs)
+        _, loss2, recon2, metrics2 = train_step(state2, inputs)
+
+        np.testing.assert_array_equal(loss1, loss2)
+        np.testing.assert_array_equal(recon1, recon2)
+        for key in metrics1.keys():
+            np.testing.assert_array_equal(metrics1[key], metrics2[key])
+
+    def test_multiple_forward_passes_reproducibility(self):
+        """Test that multiple forward passes with same seed are reproducible."""
+        tokenizer = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=self.dropout,
+            codebook_dropout=self.codebook_dropout,
+        )
+
+        params = tokenizer.init(self.rng, {"videos": self.test_videos})
+
+        base_rng = jax.random.PRNGKey(123)
+        outputs = []
+        for i in range(3):
+            rng_dropout = jax.random.fold_in(base_rng, i)
+            output = tokenizer.apply(
+                params,
+                {"videos": self.test_videos},
+                training=True,
+                rngs={"dropout": rng_dropout},
+            )
+            outputs.append(output)
+
+        outputs2 = []
+        for i in range(3):
+            rng_dropout = jax.random.fold_in(base_rng, i)
+            output = tokenizer.apply(
+                params,
+                {"videos": self.test_videos},
+                training=True,
+                rngs={"dropout": rng_dropout},
+            )
+            outputs2.append(output)
+
+        for i in range(3):
+            for key in outputs[i].keys():
+                np.testing.assert_array_equal(outputs[i][key], outputs2[i][key])
+
+    def test_tokenizer_indices_consistency(self):
+        """Test that tokenizer produces consistent indices for same input."""
+        tokenizer = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=0.0,
+            codebook_dropout=0.0,
+        )
+
+        rng = jax.random.PRNGKey(self.seed)
+        test_videos = jax.random.uniform(
+            rng,
+            (
+                self.batch_size,
+                self.seq_len,
+                self.image_height,
+                self.image_width,
+                self.image_channels,
+            ),
+        )
+        params = tokenizer.init(rng, {"videos": test_videos})
+
+        indices_list = []
+        for _ in range(3):
+            output = tokenizer.apply(
+                params, test_videos, method=tokenizer.vq_encode, training=True
+            )
+            indices_list.append(output["indices"])
+
+        for i in range(1, len(indices_list)):
+            np.testing.assert_array_equal(indices_list[0], indices_list[i])
+
+    def test_different_dropout_rngs_produce_different_outputs(self):
+        """Test that different dropout RNGs produce different outputs (sanity check)."""
+        tokenizer = TokenizerVQVAE(
+            in_dim=self.image_channels,
+            model_dim=self.model_dim,
+            latent_dim=self.latent_dim,
+            num_latents=self.num_latents,
+            patch_size=self.patch_size,
+            num_blocks=self.num_blocks,
+            num_heads=self.num_heads,
+            dropout=self.dropout,
+            codebook_dropout=self.codebook_dropout,
+        )
+
+        params = tokenizer.init(self.rng, {"videos": self.test_videos})
+
+        rng1 = jax.random.PRNGKey(123)
+        rng2 = jax.random.PRNGKey(456)
+
+        output1 = tokenizer.apply(
+            params, {"videos": self.test_videos}, training=True, rngs={"dropout": rng1}
+        )
+        output2 = tokenizer.apply(
+            params, {"videos": self.test_videos}, training=True, rngs={"dropout": rng2}
+        )
+
+        for key in output1.keys():
+            if key in ["recon", "z_q", "z", "emb"]:
+                with self.assertRaises(AssertionError):
+                    np.testing.assert_array_equal(output1[key], output2[key])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -11,6 +11,7 @@ import optax
 import orbax
 from orbax.checkpoint import PyTreeCheckpointer
 import numpy as np
+import tensorflow as tf
 import jax
 import jax.numpy as jnp
 import tyro
@@ -72,6 +73,8 @@ class Args:
 
 
 args = tyro.cli(Args)
+tf.random.set_seed(args.seed)
+np.random.seed(args.seed)
 
 
 def dynamics_loss_fn(params, state, inputs):

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -11,7 +11,6 @@ import optax
 import orbax
 from orbax.checkpoint import PyTreeCheckpointer
 import numpy as np
-import tensorflow as tf
 import jax
 import jax.numpy as jnp
 import tyro
@@ -73,8 +72,6 @@ class Args:
 
 
 args = tyro.cli(Args)
-tf.random.set_seed(args.seed)
-np.random.seed(args.seed)
 
 
 def dynamics_loss_fn(params, state, inputs):
@@ -125,7 +122,7 @@ if __name__ == "__main__":
             f"Global batch size {args.batch_size} must be divisible by "
             f"number of devices {num_devices}."
         )
-    
+
     per_device_batch_size_for_init = args.batch_size // num_devices
 
     rng = jax.random.PRNGKey(args.seed)
@@ -160,9 +157,12 @@ if __name__ == "__main__":
     image_shape = (args.image_resolution, args.image_resolution, args.image_channels)
     dummy_inputs = dict(
         videos=jnp.zeros(
-            (per_device_batch_size_for_init, args.seq_len, *image_shape), dtype=jnp.float32
+            (per_device_batch_size_for_init, args.seq_len, *image_shape),
+            dtype=jnp.float32,
         ),
-        action=jnp.zeros((per_device_batch_size_for_init, args.seq_len), dtype=jnp.float32),
+        action=jnp.zeros(
+            (per_device_batch_size_for_init, args.seq_len), dtype=jnp.float32
+        ),
         mask_rng=_rng,
     )
     rng, _rng = jax.random.split(rng)
@@ -176,13 +176,15 @@ if __name__ == "__main__":
     train_state = TrainState.create(apply_fn=genie.apply, params=init_params, tx=tx)
 
     device_mesh_arr = create_device_mesh((num_devices,))
-    mesh = Mesh(devices=device_mesh_arr, axis_names=('data',))
+    mesh = Mesh(devices=device_mesh_arr, axis_names=("data",))
 
     replicated_sharding = NamedSharding(mesh, PartitionSpec())
     train_state = jax.device_put(train_state, replicated_sharding)
 
     # --- Restore checkpoint ---
-    train_state = restore_genie_components(train_state, replicated_sharding, dummy_inputs, rng, args)
+    train_state = restore_genie_components(
+        train_state, replicated_sharding, dummy_inputs, rng, args
+    )
 
     # --- TRAIN LOOP ---
     tfrecord_files = [
@@ -193,17 +195,22 @@ if __name__ == "__main__":
     dataloader = get_dataloader(
         # NOTE: We deliberately pass the global batch size
         # The dataloader shards the dataset across all processes
-        tfrecord_files, args.seq_len, args.batch_size, *image_shape
+        tfrecord_files,
+        args.seq_len,
+        args.batch_size,
+        *image_shape,
     )
     step = 0
     while step < args.num_steps:
         for videos in dataloader:
             # --- Train step ---
             rng, _rng, _mask_rng = jax.random.split(rng, 3)
-            
-            videos_sharding = NamedSharding(mesh, PartitionSpec('data', None, None, None, None))
+
+            videos_sharding = NamedSharding(
+                mesh, PartitionSpec("data", None, None, None, None)
+            )
             videos = jax.make_array_from_process_local_data(videos_sharding, videos)
-            
+
             inputs = dict(
                 videos=videos,
                 dropout_rng=_rng,
@@ -225,8 +232,8 @@ if __name__ == "__main__":
                         comparison_seq * 255, "t h w c -> h (t w) c"
                     )
                     log_images = dict(
-                        image=wandb.Image(np.asarray(gt_seq[args.seq_len-1])),
-                        recon=wandb.Image(np.asarray(recon_seq[args.seq_len-1])),
+                        image=wandb.Image(np.asarray(gt_seq[args.seq_len - 1])),
+                        recon=wandb.Image(np.asarray(recon_seq[args.seq_len - 1])),
                         true_vs_recon=wandb.Image(
                             np.asarray(comparison_seq.astype(np.uint8))
                         ),

--- a/train_lam.py
+++ b/train_lam.py
@@ -11,6 +11,7 @@ import optax
 import orbax
 from orbax.checkpoint import PyTreeCheckpointer
 import numpy as np
+import tensorflow as tf
 import dm_pix as pix
 import jax
 import jax.numpy as jnp
@@ -60,6 +61,8 @@ class Args:
 
 
 args = tyro.cli(Args)
+tf.random.set_seed(args.seed)
+np.random.seed(args.seed)
 
 
 def lam_loss_fn(params, state, inputs):

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -190,13 +190,12 @@ if __name__ == "__main__":
         step += int(args.checkpoint.split("_")[-1])
 
     # --- TRAIN LOOP ---
-    tfrecord_files = sorted(
-        [
+    tfrecord_files = [
             os.path.join(args.data_dir, x)
             for x in os.listdir(args.data_dir)
             if x.endswith(".tfrecord")
         ]
-    )
+    
     dataloader = get_dataloader(
         # NOTE: We deliberately pass the global batch size
         # The dataloader shards the dataset across all processes

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -13,6 +13,7 @@ from orbax.checkpoint import PyTreeCheckpointer
 import dm_pix as pix
 import jax
 import jax.numpy as jnp
+import numpy as np
 import tyro
 import wandb
 

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -10,8 +10,6 @@ from jax.experimental.mesh_utils import create_device_mesh
 import optax
 import orbax
 from orbax.checkpoint import PyTreeCheckpointer
-import numpy as np
-import tensorflow as tf
 import dm_pix as pix
 import jax
 import jax.numpy as jnp
@@ -62,8 +60,6 @@ class Args:
 
 
 args = tyro.cli(Args)
-tf.random.set_seed(args.seed)
-np.random.seed(args.seed)
 
 
 def tokenizer_loss_fn(params, state, inputs):
@@ -188,11 +184,13 @@ if __name__ == "__main__":
         step += int(args.checkpoint.split("_")[-1])
 
     # --- TRAIN LOOP ---
-    tfrecord_files = [
-        os.path.join(args.data_dir, x)
-        for x in os.listdir(args.data_dir)
-        if x.endswith(".tfrecord")
-    ]
+    tfrecord_files = sorted(
+        [
+            os.path.join(args.data_dir, x)
+            for x in os.listdir(args.data_dir)
+            if x.endswith(".tfrecord")
+        ]
+    )
     dataloader = get_dataloader(
         # NOTE: We deliberately pass the global batch size
         # The dataloader shards the dataset across all processes

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -11,6 +11,7 @@ import optax
 import orbax
 from orbax.checkpoint import PyTreeCheckpointer
 import numpy as np
+import tensorflow as tf
 import dm_pix as pix
 import jax
 import jax.numpy as jnp
@@ -61,6 +62,8 @@ class Args:
 
 
 args = tyro.cli(Args)
+tf.random.set_seed(args.seed)
+np.random.seed(args.seed)
 
 
 def tokenizer_loss_fn(params, state, inputs):

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 
 
 # --- TensorFlow function for processing: slicing, normalization ---
-def _tf_process_episode(episode_tensor, seq_len, image_h, image_w, image_c):
+def _tf_process_episode(episode_tensor, seq_len, image_h, image_w, image_c, seed):
     """
     Processes a raw episode tensor in TensorFlow.
     Takes a full episode, extracts a random sequence, and normalizes it.
@@ -17,6 +17,7 @@ def _tf_process_episode(episode_tensor, seq_len, image_h, image_w, image_c):
         image_h: The height of each frame.
         image_w: The width of each frame.
         image_c: The number of channels in each frame.
+        seed: An integer seed for random operations to ensure reproducibility.
     Returns:
         A TensorFlow tensor representing the processed video sequence.
         Shape: (seq_len, image_h, image_w, image_c)
@@ -27,7 +28,7 @@ def _tf_process_episode(episode_tensor, seq_len, image_h, image_w, image_c):
     max_start_idx = current_episode_len - seq_len
 
     start_idx = tf.random.uniform(
-        shape=(), minval=0, maxval=max_start_idx + 1, dtype=tf.int32
+        shape=(), minval=0, maxval=max_start_idx + 1, dtype=tf.int32, seed=seed
     )
 
     seq = episode_tensor[start_idx : start_idx + seq_len]
@@ -109,6 +110,7 @@ def get_dataloader(
         image_h=image_h,
         image_w=image_w,
         image_c=image_c,
+        seed=seed
     )
     dataset = dataset.map(tf_process_fn, num_parallel_calls=num_parallel_calls)
 

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -69,7 +69,7 @@ def get_dataloader(
     image_w: int,
     image_c: int,
     shuffle_buffer_size: int = 1000,
-    num_parallel_calls: int = 1,
+    num_parallel_calls: int = tf.data.AUTOTUNE,
     cache_processed_data: bool = True,
     seed: int = 42,
 ):
@@ -103,7 +103,7 @@ def get_dataloader(
         _parse_tfrecord_fn, image_h=image_h, image_w=image_w, image_c=image_c
     )
     dataset = dataset.map(
-        parse_fn, num_parallel_calls=num_parallel_calls, deterministic=True
+        parse_fn, num_parallel_calls=num_parallel_calls
     )
 
     dataset = dataset.cache() if cache_processed_data else dataset
@@ -117,7 +117,7 @@ def get_dataloader(
         seed=seed,
     )
     dataset = dataset.map(
-        tf_process_fn, num_parallel_calls=num_parallel_calls, deterministic=True
+        tf_process_fn, num_parallel_calls=num_parallel_calls
     )
 
     dataset = dataset.repeat(None)

--- a/utils/nn.py
+++ b/utils/nn.py
@@ -42,6 +42,7 @@ class STBlock(nn.Module):
             num_heads=self.num_heads,
             qkv_features=self.dim,
             dropout_rate=self.dropout,
+            deterministic=False,
         )(z)
         x = x + z
 
@@ -54,6 +55,7 @@ class STBlock(nn.Module):
             num_heads=self.num_heads,
             qkv_features=self.dim,
             dropout_rate=self.dropout,
+            deterministic=False,
         )(z, mask=causal_mask)
         x = x + z
         x = x.swapaxes(1, 2)
@@ -112,7 +114,9 @@ class VectorQuantizer(nn.Module):
         )
         self.drop = nn.Dropout(self.dropout, deterministic=False)
 
-    def __call__(self, x: jax.Array, training: bool) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    def __call__(
+        self, x: jax.Array, training: bool
+    ) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
         # --- Compute distances ---
         x = normalize(x)
         codebook = normalize(self.codebook)


### PR DESCRIPTION
making the runs fully reproducible by fixing the seeding, the episode sampling, and setting it globally for tensorflow and numpy. tested empirically and need to set both globally for the runs to be reproducible.