### PR TITLE
fix: remove dataset caching

### DIFF
--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -69,7 +69,6 @@ def get_dataloader(
     image_c: int,
     shuffle_buffer_size: int = 1000,
     num_parallel_calls: int = tf.data.AUTOTUNE,
-    cache_processed_data: bool = True,
     seed: int = 42,
 ):
     """
@@ -102,8 +101,6 @@ def get_dataloader(
         _parse_tfrecord_fn, image_h=image_h, image_w=image_w, image_c=image_c
     )
     dataset = dataset.map(parse_fn, num_parallel_calls=num_parallel_calls)
-
-    dataset = dataset.cache() if cache_processed_data else dataset
 
     tf_process_fn = functools.partial(
         _tf_process_episode,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c311a01d-ba18-4c87-96ec-17b58f4e4f26)


Removed the tfrecord dataset caching feature. In our case, this will unnecessarily fill up memory during training.
More about it [here](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#cache)