### PR TITLE
chore: explicitly set params rng keys

### DIFF
--- a/utils/nn.py
+++ b/utils/nn.py
@@ -120,7 +120,8 @@ class VectorQuantizer(nn.Module):
         codebook = normalize(self.codebook)
         distance = -jnp.matmul(x, codebook.T)
         if training:
-            distance = self.drop(distance)
+            dropout_key = self.make_rng("dropout")
+            distance = self.drop(distance, rng=dropout_key)
 
         # --- Get indices and embeddings ---
         indices = jnp.argmin(distance, axis=-1)


### PR DESCRIPTION
## Context
- https://flax-linen.readthedocs.io/en/latest/guides/flax_fundamentals/rng_guide.html#receiving-manipulating-and-creating-prng-keys-with-module-make-rng
- https://flax-linen.readthedocs.io/en/latest/api_reference/flax.linen/module.html#flax.linen.Module.apply

We now also pass the `'params'` PRNG key to `module.apply` via `state.apply_fn`. Thus, `dropout` and `params` don't use the same key any more (which was unwanted behaviour).