### PR TITLE
feat: dont let tf see the gpus

### DIFF
--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -4,10 +4,7 @@ import jax
 import tensorflow as tf
 
 # reserve GPU memory for JAX only if tensorflow is built with GPU support
-try:
-  tf.config.experimental.set_visible_devices([], "GPU")
-except tf.errors.NotFoundError:
-  pass
+tf.config.experimental.set_visible_devices([], "GPU")
 
 
 # --- TensorFlow function for processing: slicing, normalization ---

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -3,6 +3,12 @@ import jax
 
 import tensorflow as tf
 
+# reserve GPU memory for JAX only if tensorflow is built with GPU support
+try:
+  tf.config.experimental.set_visible_devices([], "GPU")
+except tf.errors.NotFoundError:
+  pass
+
 
 # --- TensorFlow function for processing: slicing, normalization ---
 def _tf_process_episode(episode_tensor, seq_len, image_h, image_w, image_c):


### PR DESCRIPTION
dont let tf see gpus like done here: https://github.com/AI-Hypercomputer/maxtext/blob/967ab2f92e59708627a8de02f78d59003626cd74/MaxText/input_pipeline/_tfds_data_processing.py#L37-L41

and here:
https://docs.jax.dev/en/latest/notebooks/neural_network_with_tfds_data.html#data-loading-with-tensorflow-datasets