### PR TITLE
feat: add experiment name and tags to wandb

### DIFF
--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import time
 
@@ -65,6 +65,8 @@ class Args:
     log: bool = False
     entity: str = ""
     project: str = ""
+    name: str = "train_dynamics"
+    tags: list = field(default_factory=lambda: ["dynamics"])
     log_interval: int = 5
     log_image_interval: int = 250
     ckpt_dir: str = ""
@@ -131,7 +133,14 @@ if __name__ == "__main__":
 
     rng = jax.random.PRNGKey(args.seed)
     if args.log and jax.process_index() == 0:
-        wandb.init(entity=args.entity, project=args.project, group="debug", config=args)
+        wandb.init(
+            entity=args.entity,
+            project=args.project,
+            name=args.name,
+            tags=args.tags,
+            group="debug",
+            config=args
+        )
 
     # --- Initialize model ---
     genie = Genie(

--- a/train_lam.py
+++ b/train_lam.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import time
 
@@ -54,6 +54,8 @@ class Args:
     log: bool = False
     entity: str = ""
     project: str = ""
+    name: str = "train_lam"
+    tags: list = field(default_factory=lambda: ["lam"])
     log_interval: int = 5
     log_image_interval: int = 250
     ckpt_dir: str = ""
@@ -136,7 +138,14 @@ if __name__ == "__main__":
 
     rng = jax.random.PRNGKey(args.seed)
     if args.log and jax.process_index() == 0:
-        wandb.init(entity=args.entity, project=args.project, group="debug", config=args)
+        wandb.init(
+            entity=args.entity,
+            project=args.project,
+            name=args.name,
+            tags=args.tags,
+            group="debug",
+            config=args
+        ) 
 
     # --- Initialize model ---
     lam = LatentActionModel(

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import time
 
@@ -53,6 +53,8 @@ class Args:
     log: bool = False
     entity: str = ""
     project: str = ""
+    name: str = "train_tokenizer"
+    tags: list = field(default_factory=lambda: ["tokenizer"])
     log_interval: int = 5
     log_image_interval: int = 250
     ckpt_dir: str = ""
@@ -134,7 +136,14 @@ if __name__ == "__main__":
 
     rng = jax.random.PRNGKey(args.seed)
     if args.log and jax.process_index() == 0:
-        wandb.init(entity=args.entity, project=args.project, group="debug", config=args)
+        wandb.init(
+            entity=args.entity,
+            project=args.project,
+            name=args.name,
+            tags=args.tags,
+            group="debug",
+            config=args
+        )
 
     # --- Initialize model ---
     tokenizer = TokenizerVQVAE(


### PR DESCRIPTION
experiment name and tags to wandb like for this one https://wandb.ai/instant-uv/jafar/runs/8uyudx68

example usage: 

```bash
python train_tokenizer.py \
    --ckpt_dir ckpt_dir/ \
    --batch_size=12 \
    --min_lr=3e-4 \
    --max_lr=3e-4 \
    --log \
    --name=test-wandb-tags \
    --tags test tokenizer debug \
    --entity p-doom \
    --project jafar \
    --data_dir data/
```