### PR TITLE
feat: add parameter counting utilities module to print model parameter count

### DIFF
--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -20,6 +20,7 @@ from genie import Genie, restore_genie_components
 from models.tokenizer import TokenizerVQVAE
 from models.lam import LatentActionModel
 from utils.dataloader import get_dataloader
+from utils.parameter_utils import count_parameters_by_component
 
 ts = int(time.time())
 
@@ -139,7 +140,7 @@ if __name__ == "__main__":
             name=args.name,
             tags=args.tags,
             group="debug",
-            config=args
+            config=args,
         )
 
     # --- Initialize model ---
@@ -180,6 +181,10 @@ if __name__ == "__main__":
     )
     rng, _rng = jax.random.split(rng)
     init_params = genie.init(_rng, dummy_inputs)
+
+    param_counts = count_parameters_by_component(init_params)
+    print("Parameter counts:")
+    print(param_counts)
 
     # --- Initialize optimizer ---
     lr_schedule = optax.warmup_cosine_decay_schedule(

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -174,8 +174,6 @@ if __name__ == "__main__":
     init_params = genie.init(_rng, dummy_inputs)
 
     param_counts = count_parameters_by_component(init_params)
-    print("Parameter counts:")
-    print(param_counts)
 
     if args.log and jax.process_index() == 0:
         wandb.init(
@@ -187,6 +185,9 @@ if __name__ == "__main__":
             config=args,
         )
         wandb.config.update({"model_param_count": param_counts})
+
+    print("Parameter counts:")
+    print(param_counts)
 
     # --- Initialize optimizer ---
     lr_schedule = optax.warmup_cosine_decay_schedule(

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -133,15 +133,6 @@ if __name__ == "__main__":
     per_device_batch_size_for_init = args.batch_size // num_devices
 
     rng = jax.random.PRNGKey(args.seed)
-    if args.log and jax.process_index() == 0:
-        wandb.init(
-            entity=args.entity,
-            project=args.project,
-            name=args.name,
-            tags=args.tags,
-            group="debug",
-            config=args,
-        )
 
     # --- Initialize model ---
     genie = Genie(
@@ -185,6 +176,17 @@ if __name__ == "__main__":
     param_counts = count_parameters_by_component(init_params)
     print("Parameter counts:")
     print(param_counts)
+
+    if args.log and jax.process_index() == 0:
+        wandb.init(
+            entity=args.entity,
+            project=args.project,
+            name=args.name,
+            tags=args.tags,
+            group="debug",
+            config=args,
+        )
+        wandb.config.update({"model_param_count": param_counts})
 
     # --- Initialize optimizer ---
     lr_schedule = optax.warmup_cosine_decay_schedule(

--- a/train_lam.py
+++ b/train_lam.py
@@ -19,6 +19,7 @@ import wandb
 
 from models.lam import LatentActionModel
 from utils.dataloader import get_dataloader
+from utils.parameter_utils import count_parameters_by_component
 
 ts = int(time.time())
 
@@ -144,7 +145,7 @@ if __name__ == "__main__":
             name=args.name,
             tags=args.tags,
             group="debug",
-            config=args
+            config=args,
         )
 
     # --- Initialize model ---
@@ -172,6 +173,10 @@ if __name__ == "__main__":
     )
     rng, _rng = jax.random.split(rng)
     init_params = lam.init(_rng, inputs)
+
+    param_counts = count_parameters_by_component(init_params)
+    print("Parameter counts:")
+    print(param_counts)
 
     # --- Initialize optimizer ---
     lr_schedule = optax.warmup_cosine_decay_schedule(

--- a/train_lam.py
+++ b/train_lam.py
@@ -138,15 +138,6 @@ if __name__ == "__main__":
     per_device_batch_size_for_init = args.batch_size // num_devices
 
     rng = jax.random.PRNGKey(args.seed)
-    if args.log and jax.process_index() == 0:
-        wandb.init(
-            entity=args.entity,
-            project=args.project,
-            name=args.name,
-            tags=args.tags,
-            group="debug",
-            config=args,
-        )
 
     # --- Initialize model ---
     lam = LatentActionModel(
@@ -177,6 +168,17 @@ if __name__ == "__main__":
     param_counts = count_parameters_by_component(init_params)
     print("Parameter counts:")
     print(param_counts)
+
+    if args.log and jax.process_index() == 0:
+        wandb.init(
+            entity=args.entity,
+            project=args.project,
+            name=args.name,
+            tags=args.tags,
+            group="debug",
+            config=args,
+        )
+        wandb.config.update({"model_param_count": param_counts})
 
     # --- Initialize optimizer ---
     lr_schedule = optax.warmup_cosine_decay_schedule(

--- a/train_lam.py
+++ b/train_lam.py
@@ -166,8 +166,6 @@ if __name__ == "__main__":
     init_params = lam.init(_rng, inputs)
 
     param_counts = count_parameters_by_component(init_params)
-    print("Parameter counts:")
-    print(param_counts)
 
     if args.log and jax.process_index() == 0:
         wandb.init(
@@ -179,6 +177,9 @@ if __name__ == "__main__":
             config=args,
         )
         wandb.config.update({"model_param_count": param_counts})
+
+    print("Parameter counts:")
+    print(param_counts)
 
     # --- Initialize optimizer ---
     lr_schedule = optax.warmup_cosine_decay_schedule(

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -136,15 +136,6 @@ if __name__ == "__main__":
     per_device_batch_size_for_init = args.batch_size // num_devices
 
     rng = jax.random.PRNGKey(args.seed)
-    if args.log and jax.process_index() == 0:
-        wandb.init(
-            entity=args.entity,
-            project=args.project,
-            name=args.name,
-            tags=args.tags,
-            group="debug",
-            config=args,
-        )
 
     # --- Initialize model ---
     tokenizer = TokenizerVQVAE(
@@ -171,6 +162,16 @@ if __name__ == "__main__":
     param_counts = count_parameters_by_component(init_params)
     print("Parameter counts:")
     print(param_counts)
+
+    if args.log and jax.process_index() == 0:
+        wandb.init(
+            entity=args.entity,
+            project=args.project,
+            name=args.name,
+            tags=args.tags,
+            group="debug",
+            config={**vars(args), "model_param_count": param_counts},
+        )
 
     # --- Initialize optimizer ---
     lr_schedule = optax.warmup_cosine_decay_schedule(

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -19,6 +19,7 @@ import wandb
 
 from models.tokenizer import TokenizerVQVAE
 from utils.dataloader import get_dataloader
+from utils.parameter_utils import count_parameters_by_component
 
 ts = int(time.time())
 
@@ -142,7 +143,7 @@ if __name__ == "__main__":
             name=args.name,
             tags=args.tags,
             group="debug",
-            config=args
+            config=args,
         )
 
     # --- Initialize model ---
@@ -166,6 +167,10 @@ if __name__ == "__main__":
         ),
     )
     init_params = tokenizer.init(_rng, inputs)
+
+    param_counts = count_parameters_by_component(init_params)
+    print("Parameter counts:")
+    print(param_counts)
 
     # --- Initialize optimizer ---
     lr_schedule = optax.warmup_cosine_decay_schedule(

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -160,8 +160,6 @@ if __name__ == "__main__":
     init_params = tokenizer.init(_rng, inputs)
 
     param_counts = count_parameters_by_component(init_params)
-    print("Parameter counts:")
-    print(param_counts)
 
     if args.log and jax.process_index() == 0:
         wandb.init(
@@ -170,8 +168,12 @@ if __name__ == "__main__":
             name=args.name,
             tags=args.tags,
             group="debug",
-            config={**vars(args), "model_param_count": param_counts},
+            config=args,
         )
+        wandb.config.update({"model_param_count": param_counts})
+
+    print("Parameter counts:")
+    print(param_counts)
 
     # --- Initialize optimizer ---
     lr_schedule = optax.warmup_cosine_decay_schedule(

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -70,7 +70,7 @@ def get_dataloader(
     image_h: int,
     image_w: int,
     image_c: int,
-    shuffle_buffer_size: int = 1000,
+    shuffle_buffer_size: int = 50,
     num_parallel_calls: int = tf.data.AUTOTUNE,
     seed: int = 42,
 ):

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -70,7 +70,7 @@ def get_dataloader(
     image_h: int,
     image_w: int,
     image_c: int,
-    shuffle_buffer_size: int = 50,
+    shuffle_buffer_size: int = 1000,
     num_parallel_calls: int = tf.data.AUTOTUNE,
     seed: int = 42,
 ):

--- a/utils/parameter_utils.py
+++ b/utils/parameter_utils.py
@@ -1,0 +1,46 @@
+from jax.tree_util import tree_map, tree_reduce
+
+
+def count_leaf(x):
+    """Count parameters in a single leaf node."""
+    if hasattr(x, "size"):
+        return x.size
+    return 0
+
+
+def count_component(component_params):
+    """Count total parameters in a component."""
+    return tree_reduce(
+        lambda x, y: x + y, tree_map(count_leaf, component_params), initializer=0
+    )
+
+
+def count_parameters_by_component(params):
+    """Count parameters for each component of the model.
+
+    Args:
+        params: Model parameters dictionary
+        component_names: List of component names to count. If None, counts all components.
+
+    Returns:
+        Dictionary with parameter counts for each component
+    """
+
+    component_names = list(params["params"].keys())
+    print(f"Counting all components: {component_names}")
+
+    counts = {}
+    total_params = 0
+
+    for name in component_names:
+        if "params" in params and name in params["params"]:
+            component_params = params["params"][name]
+        else:
+            component_params = params
+
+        count = count_component(component_params)
+        counts[name] = count
+        total_params += count
+
+    counts["total"] = total_params
+    return counts


### PR DESCRIPTION
## Feature: parameter count is printed for each model (tokenizer, lam, dynamics)
- created utils/parameter_utils.py with parameter count function
- updated all training scripts to import from the new utility module

**Note**: pre-commit hook added a `,` after the `config=args` as well

**Example looks like this:**
![image](https://github.com/user-attachments/assets/26f040e3-7b48-484f-8520-d8e3099c859a)
Tokenizer wandb.yaml example

