### PR TITLE
feat: revised dataloader for increased throughput

### DIFF
--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -63,43 +63,10 @@ def _parse_tfrecord_fn(example_proto, image_h, image_w, image_c):
     return episode_tensor
 
 
-def get_dataloader(
-    tfrecord_paths: list[str],  # List of TFRecord file paths
-    seq_len: int,
-    global_batch_size: int,
-    image_h: int,
-    image_w: int,
-    image_c: int,
-    shuffle_buffer_size: int = 1000,
-    num_parallel_calls: int = tf.data.AUTOTUNE,
-    seed: int = 42,
-):
-    """
-    Creates a tf.data.Dataset pipeline from TFRecord files.
-    """
-    if not tfrecord_paths:
-        raise ValueError("tfrecord_paths list cannot be empty.")
-
-    process_id = jax.process_index()
-    num_processes = jax.process_count()
-
-    assert (
-        global_batch_size % num_processes == 0
-    ), "Global batch size {global_batch_size} \
-        must be divisible by the number of JAX processes {num_processes} for proper sharding."
-    per_process_batch_size = global_batch_size // num_processes
-
-    dataset = tf.data.TFRecordDataset(
-        tfrecord_paths, num_parallel_reads=tf.data.AUTOTUNE
-    )
-
-    dataset = dataset.shard(num_shards=num_processes, index=process_id)
-
-    # (f.srambical) NOTE: For TFRecords, it's often good to have a large shuffle buffer.
-    if shuffle_buffer_size > 0:
-        dataset = dataset.shuffle(
-            buffer_size=shuffle_buffer_size, seed=seed, reshuffle_each_iteration=True
-        )
+def _create_processed_dataset_from_file(file_path, image_h, image_w, image_c, seq_len, num_parallel_calls):
+    """Creates a fully processed dataset from a single TFRecord file."""
+    dataset = tf.data.TFRecordDataset([file_path])
+    
     parse_fn = functools.partial(
         _parse_tfrecord_fn, image_h=image_h, image_w=image_w, image_c=image_c
     )
@@ -113,6 +80,58 @@ def get_dataloader(
         image_c=image_c,
     )
     dataset = dataset.map(tf_process_fn, num_parallel_calls=num_parallel_calls)
+    
+    return dataset
+
+
+def get_dataloader(
+    tfrecord_paths: list[str],
+    seq_len: int,
+    global_batch_size: int,
+    image_h: int,
+    image_w: int,
+    image_c: int,
+    shuffle_buffer_size: int = 1000,
+    num_parallel_calls: int = tf.data.AUTOTUNE,
+    seed: int = 42,
+    cycle_length: int = 4,
+    block_length: int = 1,
+):
+    """
+    Creates a tf.data.Dataset pipeline from TFRecord files.
+    """
+    if not tfrecord_paths:
+        raise ValueError("tfrecord_paths list cannot be empty.")
+
+    process_id = jax.process_index()
+    num_processes = jax.process_count()
+
+    assert (
+        global_batch_size % num_processes == 0
+    ), f"Global batch size {global_batch_size} \
+        must be divisible by the number of JAX processes {num_processes} for proper sharding."
+    per_process_batch_size = global_batch_size // num_processes
+
+    def dataset_fn(file_path):
+        return _create_processed_dataset_from_file(
+            file_path, image_h, image_w, image_c, seq_len, num_parallel_calls
+        )
+    
+    dataset = tf.data.Dataset.from_tensor_slices(tfrecord_paths)
+    dataset = dataset.shard(num_shards=num_processes, index=process_id)
+    
+    dataset = dataset.interleave(
+        dataset_fn,
+        cycle_length=cycle_length,
+        block_length=block_length,
+        num_parallel_calls=num_parallel_calls,
+        deterministic=False
+    )
+    
+    if shuffle_buffer_size > 0:
+        dataset = dataset.shuffle(
+            buffer_size=shuffle_buffer_size, seed=seed, reshuffle_each_iteration=True
+        )
 
     dataset = dataset.repeat(None)
     dataset = dataset.batch(per_process_batch_size, drop_remainder=True)


### PR DESCRIPTION
- This is a draft PR since the 'revised' dataloader still leads to non-overlapping compute and I/O
- However, in my tests on 4 nodes (à 4 A100s), we are almost completely compute-bound (averaging ~2.5s per step, which is at least remotely close to the optimal 2.33s); so until I have solved the issue with `.prefetch` not working as intended, we can use this dataloader for ad-hoc experiments