### PR TITLE
feat: switched dataloader to grain

### DIFF
--- a/genie.py
+++ b/genie.py
@@ -246,7 +246,7 @@ class MaskGITStep(nn.Module):
 
 def restore_genie_components(
     train_state: TrainState,
-    sharding: jax.sharding.Sharding,
+    sharding: jax.sharding.NamedSharding,
     grain_iterator: grain.DataLoaderIterator,
     inputs: Dict[str, jax.Array],
     rng: jax.Array,

--- a/genie.py
+++ b/genie.py
@@ -4,14 +4,15 @@ import optax
 import jax
 import jax.numpy as jnp
 import flax.linen as nn
-from jax import NamedSharding
 from flax.training.train_state import TrainState
-from flax.training import orbax_utils
-from orbax.checkpoint import PyTreeCheckpointer
+import orbax.checkpoint as ocp
 
 from models.dynamics import DynamicsMaskGIT
 from models.lam import LatentActionModel
 from models.tokenizer import TokenizerVQVAE
+
+import os
+import grain
 
 
 class Genie(nn.Module):
@@ -245,7 +246,8 @@ class MaskGITStep(nn.Module):
 
 def restore_genie_components(
     train_state: TrainState,
-    sharding: NamedSharding,
+    sharding: jax.sharding.Sharding,
+    grain_iterator: grain.DataLoaderIterator,
     inputs: Dict[str, jax.Array],
     rng: jax.Array,
     args,
@@ -260,7 +262,19 @@ def restore_genie_components(
         b2=0.9,
         weight_decay=1e-4,
     )
+    handler_registry = ocp.handlers.DefaultCheckpointHandlerRegistry()
+    handler_registry.add('model_state', ocp.args.StandardRestore, ocp.handlers.StandardCheckpointHandler)
+    handler_registry.add('dataloader_state', grain.checkpoint.CheckpointRestore, grain.checkpoint.CheckpointHandler)
+    
 
+    checkpoint_options = ocp.CheckpointManagerOptions(
+        step_format_fixed_length=6,
+    )
+    tokenizer_checkpoint_manager = ocp.CheckpointManager(
+        directory=args.tokenizer_checkpoint,
+        options=checkpoint_options,
+        handler_registry=handler_registry,
+    )
     dummy_tokenizer = TokenizerVQVAE(
         in_dim=args.image_channels,
         model_dim=args.tokenizer_dim,
@@ -279,22 +293,23 @@ def restore_genie_components(
     abstract_sharded_tokenizer_state = _create_abstract_sharded_pytree(
         dummy_tokenizer_train_state, sharding
     )
-    tokenizer_restore_target = {"model": abstract_sharded_tokenizer_state}
-    tokenizer_restore_args = orbax_utils.restore_args_from_target(
-        tokenizer_restore_target
-    )
-    restored_tokenizer_params = (
-        PyTreeCheckpointer()
-        .restore(
-            args.tokenizer_checkpoint,
-            item=tokenizer_restore_target,
-            restore_args=tokenizer_restore_args,
-        )["model"]
-        .params["params"]
-    )
+    restored_tokenizer = tokenizer_checkpoint_manager.restore(
+        step=tokenizer_checkpoint_manager.latest_step(),
+        args=ocp.args.Composite(
+            model_state=ocp.args.StandardRestore(abstract_sharded_tokenizer_state),
+            dataloader_state=grain.checkpoint.CheckpointRestore(grain_iterator),
+        ),
+    )["model_state"]
+    restored_tokenizer_params = restored_tokenizer.params["params"]
     train_state.params["params"]["tokenizer"].update(restored_tokenizer_params)
+    tokenizer_checkpoint_manager.close()
 
     if args.lam_checkpoint:
+        lam_checkpoint_manager = ocp.CheckpointManager(
+            directory=args.lam_checkpoint,
+            options=checkpoint_options,
+            handler_registry=handler_registry,
+        )
         dummy_lam = LatentActionModel(
             in_dim=args.image_channels,
             model_dim=args.lam_dim,
@@ -313,15 +328,14 @@ def restore_genie_components(
         abstract_sharded_lam_state = _create_abstract_sharded_pytree(
             dummy_lam_train_state, sharding
         )
-        lam_restore_target = {"model": abstract_sharded_lam_state}
-        lam_restore_args = orbax_utils.restore_args_from_target(lam_restore_target)
-        restored_lam_params = (
-            PyTreeCheckpointer()
-            .restore(
-                args.lam_checkpoint, item=lam_restore_target, restore_args=lam_restore_args
-            )["model"]
-            .params["params"]
-        )
+        restored_lam = lam_checkpoint_manager.restore(
+            step=lam_checkpoint_manager.latest_step(),
+            args=ocp.args.Composite(
+                model_state=ocp.args.StandardRestore(abstract_sharded_lam_state),
+                dataloader_state=grain.checkpoint.CheckpointRestore(grain_iterator),
+            ),
+        )["model_state"]
+        restored_lam_params = restored_lam.params["params"]
         # Genie does not initialize all LAM modules, thus we omit those extra modules during restoration
         # (f.srambical) FIXME: Currently, this is a small HBM memory crunch since the LAM's decoder is loaded into HBM and immediately dicarded.
         # A workaround would be to restore to host memory first, and only move the weights to HBM after pruning the decoder
@@ -331,9 +345,9 @@ def restore_genie_components(
             if k in train_state.params["params"]["lam"]
         }
         train_state.params["params"]["lam"].update(restored_lam_params)
+        lam_checkpoint_manager.close()
 
     return train_state
-
 
 def _create_abstract_sharded_pytree(pytree_template, sharding_spec):
     """Replaces arrays in a pytree with ShapeDtypeStructs having the given sharding."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ optax>=0.2.3
 procgen>=0.10.7
 tyro>=0.8.5
 wandb>=0.17.4
-tensorflow>=2.1
+grain>=0.2.10
 pre-commit>=4.2.0
+array-record>=0.7.2

--- a/sample.py
+++ b/sample.py
@@ -109,18 +109,20 @@ def _autoreg_sample(rng, video_batch, action_batch):
 
 
 # --- Get video + latent actions ---
-tfrecord_files = [
+array_record_files = [
     os.path.join(args.data_dir, x)
     for x in os.listdir(args.data_dir)
-    if x.endswith(".tfrecord")
+    if x.endswith(".array_record")
 ]
 dataloader = get_dataloader(
-    tfrecord_files,
+    array_record_files,
     args.seq_len,
     args.batch_size,
     args.image_height,
     args.image_width,
     args.image_channels,
+    num_workers=8,
+    prefetch_buffer_size=1,
     seed=args.seed,
 )
 video_batch = next(iter(dataloader))

--- a/tests/data/generate_dummy_data.py
+++ b/tests/data/generate_dummy_data.py
@@ -1,61 +1,54 @@
-import tyro
-import tensorflow as tf
+import pickle
 import numpy as np
 from pathlib import Path
-from dataclasses import dataclass
-
-@dataclass
-class Args:
-    data_dir: str = "data_tfrecords/dummy"
-    num_episodes: int = 5
-    episode_length: int = 16
+from array_record.python.array_record_module import ArrayRecordWriter
 
 
-
-def _bytes_feature(value):
-    """Returns a bytes_list from a string / byte."""
-    if isinstance(value, type(tf.constant(0))):
-        value = value.numpy()  # BytesList won't unpack a string from an EagerTensor.
-    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
-
-
-def _int64_feature(value):
-    """Returns an int64_list from a bool / enum / int / uint."""
-    return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
-
-
-def create_tfrecord_example(episode_numpy_array):
-    """Creates a TFRecord example from a numpy array video."""
-    feature = {
-        "height": _int64_feature(episode_numpy_array.shape[1]),
-        "width": _int64_feature(episode_numpy_array.shape[2]),
-        "channels": _int64_feature(episode_numpy_array.shape[3]),
-        "sequence_length": _int64_feature(episode_numpy_array.shape[0]),
-        "raw_video": _bytes_feature(episode_numpy_array.tobytes()),
-    }
-    return tf.train.Example(features=tf.train.Features(feature=feature))
-
-
-def generate_dummy_tfrecord(
-    output_path, num_episodes=5, episode_length=16, height=90, width=160, channels=3
+def generate_dummy_arrayrecord(
+    output_path: Path,
+    num_videos: int = 5,
+    episode_length: int = 16,
+    height: int = 64,
+    width: int = 64,
+    channels: int = 3,
+    seed: int = 42
 ):
-    """Generates a dummy TFRecord file with synthetic video data."""
-    print(f"Generating dummy TFRecord file at {output_path}")
-    with tf.io.TFRecordWriter(str(output_path)) as writer:
-        for i in range(num_episodes):
-            np.random.seed(i)  # Seed per episode for some variation, but deterministic
+    """Generates a dummy ArrayRecord file with synthetic video data for testing."""
+    print(f"Generating dummy ArrayRecord file at {output_path}")
+    
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    writer = ArrayRecordWriter(str(output_path), "group_size:1")
+    try:
+        for i in range(num_videos):
+            np.random.seed(seed + i)
             dummy_video = np.random.randint(
                 0, 256, size=(episode_length, height, width, channels), dtype=np.uint8
             )
-            tf_example = create_tfrecord_example(dummy_video)
-            writer.write(tf_example.SerializeToString())
-    print("Dummy TFRecord generation complete.")
+            
+            record = {
+                "raw_video": dummy_video.tobytes(),
+                "sequence_length": episode_length
+            }
+            
+            writer.write(pickle.dumps(record))
+    finally:
+        writer.close()
+    
+    print("Dummy ArrayRecord generation complete.")
 
 
 if __name__ == "__main__":
-    args = tyro.cli(Args)
-    temp_dir = Path(args.data_dir)
-    temp_dir.mkdir(parents=True, exist_ok=True)
-    dummy_file = temp_dir / "dummy_test_shard.tfrecord"
-    generate_dummy_tfrecord(dummy_file, num_episodes=args.num_episodes, episode_length=args.episode_length)
-    print(f"Generated dummy file: {dummy_file}")
+    test_dir = Path("tests/data/dummy_arrayrecord")
+    test_dir.mkdir(parents=True, exist_ok=True)
+    dummy_file = test_dir / "dummy_test_shard.array_record"
+    
+    generate_dummy_arrayrecord(
+        dummy_file,
+        num_videos=5,
+        episode_length=16,
+        height=64,
+        width=64,
+        channels=3
+    )
+    print(f"Generated dummy file: {dummy_file}") 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 
 from utils.dataloader import get_dataloader
-from tests.data.generate_dummy_arrayrecord import generate_dummy_arrayrecord
+from tests.data.generate_dummy_data import generate_dummy_arrayrecord
 
 
 class DataloaderReproducibilityTest(unittest.TestCase):

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,11 +1,11 @@
 import unittest
 import numpy as np
-import tensorflow as tf
 import tempfile
+import os
 from pathlib import Path
 
 from utils.dataloader import get_dataloader
-from tests.data.generate_dummy_tfrecord import generate_dummy_tfrecord
+from tests.data.generate_dummy_arrayrecord import generate_dummy_arrayrecord
 
 
 class DataloaderReproducibilityTest(unittest.TestCase):
@@ -15,22 +15,29 @@ class DataloaderReproducibilityTest(unittest.TestCase):
         self._temp_dir_manager = tempfile.TemporaryDirectory()
         self.test_data_dir = Path(self._temp_dir_manager.name)
         self.addCleanup(self._temp_dir_manager.cleanup)
-        self.dummy_tfrecord_path = self.test_data_dir / "dummy_test_shard.tfrecord"
 
-        self.num_episodes = 5
+        self.num_videos = 10
         self.episode_length = 16
         self.image_height = 64
         self.image_width = 64
         self.image_channels = 3
-        generate_dummy_tfrecord(
-            self.dummy_tfrecord_path,
-            num_episodes=self.num_episodes,
+        
+        dummy_file = self.test_data_dir / "dummy_test_shard.array_record"
+        generate_dummy_arrayrecord(
+            dummy_file,
+            num_videos=self.num_videos,
             episode_length=self.episode_length,
             height=self.image_height,
             width=self.image_width,
             channels=self.image_channels,
+            seed=42
         )
-        self.tfrecord_files = [str(self.dummy_tfrecord_path)]
+        
+        self.array_record_files = [
+            str(self.test_data_dir / f) 
+            for f in os.listdir(self.test_data_dir) 
+            if f.endswith('.array_record')
+        ]
 
         self.fixed_seed = 42
 
@@ -39,7 +46,7 @@ class DataloaderReproducibilityTest(unittest.TestCase):
         batch_size = 2
 
         dataloader1 = get_dataloader(
-            self.tfrecord_files,
+            self.array_record_files,
             seq_len,
             batch_size,
             self.image_height,
@@ -50,7 +57,7 @@ class DataloaderReproducibilityTest(unittest.TestCase):
         batches1 = [next(dataloader1) for _ in range(3)]
 
         dataloader2 = get_dataloader(
-            self.tfrecord_files,
+            self.array_record_files,
             seq_len,
             batch_size,
             self.image_height,
@@ -61,7 +68,7 @@ class DataloaderReproducibilityTest(unittest.TestCase):
         batches2 = [next(dataloader2) for _ in range(3)]
 
         for i, (b1, b2) in enumerate(zip(batches1, batches2)):
-            np.testing.assert_array_equal(b1, b2, err_msg=f"Batch {i} is not reproducible")  # type: ignore
+            np.testing.assert_array_equal(b1, b2, err_msg=f"Batch {i} is not reproducible")
 
 
 if __name__ == "__main__":

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -52,6 +52,8 @@ class DataloaderReproducibilityTest(unittest.TestCase):
             self.image_height,
             self.image_width,
             self.image_channels,
+            num_workers=8,
+            prefetch_buffer_size=1,
             seed=self.fixed_seed,
         )
         batches1 = [next(dataloader1) for _ in range(3)]
@@ -63,6 +65,8 @@ class DataloaderReproducibilityTest(unittest.TestCase):
             self.image_height,
             self.image_width,
             self.image_channels,
+            num_workers=8,
+            prefetch_buffer_size=1,
             seed=self.fixed_seed,
         )
         batches2 = [next(dataloader2) for _ in range(3)]

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -68,6 +68,7 @@ class Args:
     log_image_interval: int = 250
     ckpt_dir: str = ""
     log_checkpoint_interval: int = 25000
+    log_checkpoint_keep_period: int = 20000
     log_gradients: bool = False
 
 
@@ -213,6 +214,7 @@ if __name__ == "__main__":
     checkpoint_options = ocp.CheckpointManagerOptions(
         save_interval_steps=args.log_checkpoint_interval,
         max_to_keep=3,
+        keep_period=args.log_checkpoint_keep_period,
         step_format_fixed_length=6,
         cleanup_tmp_directories=True,
     )

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -211,18 +211,21 @@ if __name__ == "__main__":
     )
 
     # --- TRAIN LOOP ---
-    tfrecord_files = [
+    array_record_files = [
         os.path.join(args.data_dir, x)
         for x in os.listdir(args.data_dir)
-        if x.endswith(".tfrecord")
+        if x.endswith(".array_record")
     ]
     dataloader = get_dataloader(
         # NOTE: We deliberately pass the global batch size
         # The dataloader shards the dataset across all processes
-        tfrecord_files,
+        array_record_files,
         args.seq_len,
         args.batch_size,
         *image_shape,
+        num_workers=8,
+        prefetch_buffer_size=1,
+        seed=args.seed,
     )
     dataloader = (jax.make_array_from_process_local_data(videos_sharding, elem) for elem in dataloader) # type: ignore
     step = 0

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -2,22 +2,19 @@ from dataclasses import dataclass, field
 import os
 
 import einops
-from flax.training import orbax_utils
 from flax.training.train_state import TrainState
 from jax.sharding import Mesh, PartitionSpec, NamedSharding
 from jax.experimental.mesh_utils import create_device_mesh
 import optax
-import orbax
-from orbax.checkpoint import PyTreeCheckpointer
+import orbax.checkpoint as ocp
 import numpy as np
 import jax
 import jax.numpy as jnp
 import tyro
 import wandb
+import grain
 
 from genie import Genie, restore_genie_components
-from models.tokenizer import TokenizerVQVAE
-from models.lam import LatentActionModel
 from utils.dataloader import get_dataloader
 from utils.parameter_utils import count_parameters_by_component
 
@@ -32,6 +29,8 @@ class Args:
     image_height: int = 90
     image_width: int = 160
     data_dir: str = ""
+    save_ckpt: bool = False
+    restore_ckpt: bool = False
     # Optimization
     batch_size: int = 36
     min_lr: float = 0.0
@@ -203,30 +202,70 @@ if __name__ == "__main__":
     )
     train_state = jax.device_put(train_state, replicated_sharding)
 
-    # --- Restore checkpoint ---
-    train_state = restore_genie_components(
-        train_state, replicated_sharding, dummy_inputs, rng, args
+    # --- Initialize checkpoint manager ---
+    step = 0
+    handler_registry = ocp.handlers.DefaultCheckpointHandlerRegistry()
+    handler_registry.add('model_state', ocp.args.StandardSave, ocp.handlers.StandardCheckpointHandler)
+    handler_registry.add('model_state', ocp.args.StandardRestore, ocp.handlers.StandardCheckpointHandler)
+    handler_registry.add('dataloader_state', grain.checkpoint.CheckpointSave, grain.checkpoint.CheckpointHandler) # type: ignore
+    handler_registry.add('dataloader_state', grain.checkpoint.CheckpointRestore, grain.checkpoint.CheckpointHandler) # type: ignore
+    
+    checkpoint_options = ocp.CheckpointManagerOptions(
+        save_interval_steps=args.log_checkpoint_interval,
+        max_to_keep=3,
+        step_format_fixed_length=6,
+        cleanup_tmp_directories=True,
+    )
+    
+    checkpoint_manager = ocp.CheckpointManager(
+        args.ckpt_dir,
+        options=checkpoint_options,
+        handler_registry=handler_registry,
     )
 
-    # --- TRAIN LOOP ---
+    # --- Create DataLoaderIterator from dataloader ---
     array_record_files = [
         os.path.join(args.data_dir, x)
         for x in os.listdir(args.data_dir)
         if x.endswith(".array_record")
     ]
-    dataloader = get_dataloader(
-        # NOTE: We deliberately pass the global batch size
-        # The dataloader shards the dataset across all processes
+    grain_dataloader = get_dataloader(
         array_record_files,
         args.seq_len,
+        # NOTE: We deliberately pass the global batch size
+        # The dataloader shards the dataset across all processes
         args.batch_size,
         *image_shape,
         num_workers=8,
         prefetch_buffer_size=1,
         seed=args.seed,
     )
-    dataloader = (jax.make_array_from_process_local_data(videos_sharding, elem) for elem in dataloader) # type: ignore
-    step = 0
+    initial_state = grain_dataloader._create_initial_state()
+    grain_iterator = grain.DataLoaderIterator(grain_dataloader, initial_state)
+    
+    # --- Restore checkpoint ---
+    if args.restore_ckpt:
+        # Restore full dynamics model
+        abstract_train_state = jax.tree_util.tree_map(ocp.utils.to_shape_dtype_struct, train_state)
+        restored = checkpoint_manager.restore(
+            checkpoint_manager.latest_step(),
+            args=ocp.args.Composite(
+                model_state=ocp.args.StandardRestore(abstract_train_state),
+                dataloader_state=grain.checkpoint.CheckpointRestore(grain_iterator),
+            )
+        )
+        train_state = restored["model_state"]
+        grain_iterator = restored["dataloader_state"]
+        step = checkpoint_manager.latest_step() or 0
+        print(f"Restored dataloader and model state from step {step}")
+    else:
+        # Restore from pre-trained tokenizer (and LAM)
+        train_state = restore_genie_components(
+            train_state, replicated_sharding, grain_iterator, dummy_inputs, rng, args
+        )
+
+    # --- TRAIN LOOP ---
+    dataloader = (jax.make_array_from_process_local_data(videos_sharding, elem) for elem in grain_iterator) # type: ignore
     while step < args.num_steps:
         for videos in dataloader:
             # --- Train step ---
@@ -268,14 +307,17 @@ if __name__ == "__main__":
                             ),
                         )
                         wandb.log(log_images)
-            if step % args.log_checkpoint_interval == 0:
-                ckpt = {"model": train_state}
-                orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
-                save_args = orbax_utils.save_args_from_target(ckpt)
-                orbax_checkpointer.save(
-                    os.path.join(os.getcwd(), args.ckpt_dir, f"genie_{step}"),
-                    ckpt,
-                    save_args=save_args,
+            # --- Checkpointing ---
+            if args.save_ckpt and step % args.log_checkpoint_interval == 0:
+                checkpoint_manager.save(
+                    step,
+                    args=ocp.args.Composite(
+                        model_state=ocp.args.StandardSave(train_state),
+                        dataloader_state=grain.checkpoint.CheckpointSave(grain_iterator),
+                    )
                 )
+                print(f"Saved checkpoint at step {step}")
             if step >= args.num_steps:
                 break
+
+    checkpoint_manager.close()

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -34,7 +34,7 @@ class Args:
     image_channels: int = 3
     image_height: int = 90
     image_width: int = 160
-    data_dir: str = "data_tfrecords/coinrun"
+    data_dir: str = ""
     # Optimization
     batch_size: int = 36
     min_lr: float = 3e-6

--- a/train_lam.py
+++ b/train_lam.py
@@ -33,7 +33,7 @@ class Args:
     image_channels: int = 3
     image_height: int = 90
     image_width: int = 160
-    data_dir: str = "data_tfrecords/coinrun"
+    data_dir: str = ""
     checkpoint: str = ""
     # Optimization
     batch_size: int = 36

--- a/train_lam.py
+++ b/train_lam.py
@@ -8,14 +8,14 @@ from flax.training.train_state import TrainState
 from jax.sharding import Mesh, PartitionSpec, NamedSharding
 from jax.experimental.mesh_utils import create_device_mesh
 import optax
-import orbax
-from orbax.checkpoint import PyTreeCheckpointer
+import orbax.checkpoint as ocp
 import numpy as np
 import dm_pix as pix
 import jax
 import jax.numpy as jnp
 import tyro
 import wandb
+import grain
 
 from models.lam import LatentActionModel
 from utils.dataloader import get_dataloader
@@ -34,7 +34,8 @@ class Args:
     image_height: int = 90
     image_width: int = 160
     data_dir: str = ""
-    checkpoint: str = ""
+    save_ckpt: bool = False
+    restore_ckpt: bool = False
     # Optimization
     batch_size: int = 36
     vq_beta: float = 0.25
@@ -82,8 +83,8 @@ def lam_loss_fn(params, state, inputs):
     # --- Compute validation metrics ---
     gt = gt_future_frames.clip(0, 1).reshape(-1, *gt_future_frames.shape[2:])
     recon = outputs["recon"].clip(0, 1).reshape(-1, *outputs["recon"].shape[2:])
-    psnr = pix.psnr(gt, recon).mean()
-    ssim = pix.ssim(gt, recon).mean()
+    psnr = pix.psnr(gt, recon).mean() # type: ignore
+    ssim = pix.ssim(gt, recon).mean() # type: ignore
     count_fn = jax.vmap(lambda i: (outputs["indices"] == i).sum())
     index_counts = count_fn(jnp.arange(args.num_latents))
     metrics = dict(
@@ -199,39 +200,64 @@ if __name__ == "__main__":
     train_state = jax.device_put(train_state, replicated_sharding)
     action_last_active = jax.device_put(action_last_active, replicated_sharding)
 
-    # --- Load checkpoint ---
+    # --- Initialize checkpoint manager ---
     step = 0
-    if args.checkpoint:
-        restore_target = {"model": train_state}
-        restore_args = orbax_utils.restore_args_from_target(restore_target)
-        train_state.params["params"].update(
-            PyTreeCheckpointer()
-            .restore(args.checkpoint, item=restore_target, restore_args=restore_args)[
-                "model"
-            ]
-            .params["params"]
-        )
-        # Assume checkpoint is of the form tokenizer_<timestamp>_<step>
-        step += int(args.checkpoint.split("_")[-1])
+    handler_registry = ocp.handlers.DefaultCheckpointHandlerRegistry()
+    handler_registry.add('model_state', ocp.args.StandardSave, ocp.handlers.StandardCheckpointHandler)
+    handler_registry.add('model_state', ocp.args.StandardRestore, ocp.handlers.StandardCheckpointHandler)
+    handler_registry.add('dataloader_state', grain.checkpoint.CheckpointSave, grain.checkpoint.CheckpointHandler) # type: ignore
+    handler_registry.add('dataloader_state', grain.checkpoint.CheckpointRestore, grain.checkpoint.CheckpointHandler) # type: ignore
+    
+    checkpoint_options = ocp.CheckpointManagerOptions(
+        save_interval_steps=args.log_checkpoint_interval,
+        max_to_keep=3,
+        step_format_fixed_length=6,
+        cleanup_tmp_directories=True,
+    )
+    
+    checkpoint_manager = ocp.CheckpointManager(
+        os.path.abspath(args.ckpt_dir),
+        options=checkpoint_options,
+        handler_registry=handler_registry,
+    )
 
-    # --- TRAIN LOOP ---
+    # --- Create DataLoaderIterator from dataloader ---
     array_record_files = [
         os.path.join(args.data_dir, x)
         for x in os.listdir(args.data_dir)
         if x.endswith(".array_record")
     ]
-    dataloader = get_dataloader(
-        # NOTE: We deliberately pass the global batch size
-        # The dataloader shards the dataset across all processes
+    grain_dataloader = get_dataloader(
         array_record_files,
         args.seq_len,
+        # NOTE: We deliberately pass the global batch size
+        # The dataloader shards the dataset across all processes
         args.batch_size,
         *image_shape,
         num_workers=8,
         prefetch_buffer_size=1,
         seed=args.seed,
     )
-    dataloader = (jax.make_array_from_process_local_data(videos_sharding, elem) for elem in dataloader) # type: ignore
+    initial_state = grain_dataloader._create_initial_state()
+    grain_iterator = grain.DataLoaderIterator(grain_dataloader, initial_state)
+    
+    # --- Restore checkpoint ---
+    if args.restore_ckpt:
+        abstract_train_state = jax.tree_util.tree_map(ocp.utils.to_shape_dtype_struct, train_state)
+        restored = checkpoint_manager.restore(
+            checkpoint_manager.latest_step(),
+            args=ocp.args.Composite(
+                model_state=ocp.args.StandardRestore(abstract_train_state),
+                dataloader_state=grain.checkpoint.CheckpointRestore(grain_iterator),
+            )
+        )
+        train_state = restored["model_state"]
+        grain_iterator = restored["dataloader_state"]
+        step = checkpoint_manager.latest_step() or 0
+        print(f"Restored dataloader and model state from step {step}")
+
+    # --- TRAIN LOOP ---
+    dataloader = (jax.make_array_from_process_local_data(videos_sharding, elem) for elem in grain_iterator) # type: ignore
     print(f"Starting training from step {step}...")
     while step < args.num_steps:
         for videos in dataloader:
@@ -271,14 +297,17 @@ if __name__ == "__main__":
                             ),
                         )
                         wandb.log(log_images)
-            if step % args.log_checkpoint_interval == 0:
-                ckpt = {"model": train_state}
-                orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
-                save_args = orbax_utils.save_args_from_target(ckpt)
-                orbax_checkpointer.save(
-                    os.path.join(os.getcwd(), args.ckpt_dir, f"lam_{ts}_{step}"),
-                    ckpt,
-                    save_args=save_args,
+            # --- Checkpointing ---
+            if args.save_ckpt and step % args.log_checkpoint_interval == 0:
+                checkpoint_manager.save(
+                    step,
+                    args=ocp.args.Composite(
+                        model_state=ocp.args.StandardSave(train_state),
+                        dataloader_state=grain.checkpoint.CheckpointSave(grain_iterator),
+                    )
                 )
+                print(f"Saved checkpoint at step {step}")
             if step >= args.num_steps:
                 break
+
+    checkpoint_manager.close()

--- a/train_lam.py
+++ b/train_lam.py
@@ -213,7 +213,7 @@ if __name__ == "__main__":
     )
     
     checkpoint_manager = ocp.CheckpointManager(
-        os.path.abspath(args.ckpt_dir),
+        args.ckpt_dir,
         options=checkpoint_options,
         handler_registry=handler_registry,
     )

--- a/train_lam.py
+++ b/train_lam.py
@@ -59,6 +59,7 @@ class Args:
     log_image_interval: int = 250
     ckpt_dir: str = ""
     log_checkpoint_interval: int = 10000
+    log_checkpoint_keep_period: int = 20000
 
 
 args = tyro.cli(Args)
@@ -208,6 +209,7 @@ if __name__ == "__main__":
     checkpoint_options = ocp.CheckpointManagerOptions(
         save_interval_steps=args.log_checkpoint_interval,
         max_to_keep=3,
+        keep_period=args.log_checkpoint_keep_period,
         step_format_fixed_length=6,
         cleanup_tmp_directories=True,
     )

--- a/train_lam.py
+++ b/train_lam.py
@@ -215,18 +215,21 @@ if __name__ == "__main__":
         step += int(args.checkpoint.split("_")[-1])
 
     # --- TRAIN LOOP ---
-    tfrecord_files = [
+    array_record_files = [
         os.path.join(args.data_dir, x)
         for x in os.listdir(args.data_dir)
-        if x.endswith(".tfrecord")
+        if x.endswith(".array_record")
     ]
     dataloader = get_dataloader(
         # NOTE: We deliberately pass the global batch size
         # The dataloader shards the dataset across all processes
-        tfrecord_files,
+        array_record_files,
         args.seq_len,
         args.batch_size,
         *image_shape,
+        num_workers=8,
+        prefetch_buffer_size=1,
+        seed=args.seed,
     )
     dataloader = (jax.make_array_from_process_local_data(videos_sharding, elem) for elem in dataloader) # type: ignore
     print(f"Starting training from step {step}...")

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -209,8 +209,8 @@ if __name__ == "__main__":
         args.seq_len,
         args.batch_size,
         *image_shape,
-        num_workers=16,
-        prefetch_buffer_size=2,
+        num_workers=8,
+        prefetch_buffer_size=1,
         seed=args.seed,
     )
     print(f"Starting training from step {step}...")

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -8,14 +8,14 @@ from flax.training.train_state import TrainState
 from jax.sharding import Mesh, PartitionSpec, NamedSharding
 from jax.experimental.mesh_utils import create_device_mesh
 import optax
-import orbax
-from orbax.checkpoint import PyTreeCheckpointer
+import orbax.checkpoint as ocp
 import numpy as np
 import dm_pix as pix
 import jax
 import jax.numpy as jnp
 import tyro
 import wandb
+import grain
 
 from models.tokenizer import TokenizerVQVAE
 from utils.dataloader import get_dataloader
@@ -34,7 +34,8 @@ class Args:
     image_height: int = 90
     image_width: int = 160
     data_dir: str = ""
-    checkpoint: str = ""
+    save_ckpt: bool = False
+    restore_ckpt: bool = False
     # Optimization
     vq_beta: float = 0.25
     batch_size: int = 48
@@ -84,8 +85,8 @@ def tokenizer_loss_fn(params, state, inputs):
     # --- Compute validation metrics ---
     gt = inputs["videos"].clip(0, 1).reshape(-1, *inputs["videos"].shape[2:])
     recon = outputs["recon"].clip(0, 1).reshape(-1, *outputs["recon"].shape[2:])
-    psnr = pix.psnr(gt, recon).mean()
-    ssim = pix.ssim(gt, recon).mean()
+    psnr = pix.psnr(gt, recon).mean() # type: ignore
+    ssim = pix.ssim(gt, recon).mean() # type: ignore
     _, index_counts = jnp.unique_counts(
         jnp.ravel(outputs["indices"]), size=args.num_latents, fill_value=0
     )
@@ -192,39 +193,64 @@ if __name__ == "__main__":
     )
     train_state = jax.device_put(train_state, replicated_sharding)
 
-    # --- Load checkpoint ---
+    # --- Initialize checkpoint manager ---
     step = 0
-    if args.checkpoint:
-        restore_target = {"model": train_state}
-        restore_args = orbax_utils.restore_args_from_target(restore_target)
-        train_state.params["params"].update(
-            PyTreeCheckpointer()
-            .restore(args.checkpoint, item=restore_target, restore_args=restore_args)[
-                "model"
-            ]
-            .params["params"]
-        )
-        # Assume checkpoint is of the form tokenizer_<timestamp>_<step>
-        step += int(args.checkpoint.split("_")[-1])
+    handler_registry = ocp.handlers.DefaultCheckpointHandlerRegistry()
+    handler_registry.add('model_state', ocp.args.StandardSave, ocp.handlers.StandardCheckpointHandler)
+    handler_registry.add('model_state', ocp.args.StandardRestore, ocp.handlers.StandardCheckpointHandler)
+    handler_registry.add('dataloader_state', grain.checkpoint.CheckpointSave, grain.checkpoint.CheckpointHandler) # type: ignore
+    handler_registry.add('dataloader_state', grain.checkpoint.CheckpointRestore, grain.checkpoint.CheckpointHandler) # type: ignore
+    
+    checkpoint_options = ocp.CheckpointManagerOptions(
+        save_interval_steps=args.log_checkpoint_interval,
+        max_to_keep=3,
+        step_format_fixed_length=6,
+        cleanup_tmp_directories=True,
+    )
+    
+    checkpoint_manager = ocp.CheckpointManager(
+        os.path.abspath(args.ckpt_dir),
+        options=checkpoint_options,
+        handler_registry=handler_registry,
+    )
 
-    # --- TRAIN LOOP ---
+    # --- Create DataLoaderIterator from dataloader ---
     array_record_files = [
         os.path.join(args.data_dir, x)
         for x in os.listdir(args.data_dir)
         if x.endswith(".array_record")
     ]
-    dataloader = get_dataloader(
-        # NOTE: We deliberately pass the global batch size
-        # The dataloader shards the dataset across all processes
+    grain_dataloader = get_dataloader(
         array_record_files,
         args.seq_len,
+        # NOTE: We deliberately pass the global batch size
+        # The dataloader shards the dataset across all processes
         args.batch_size,
         *image_shape,
         num_workers=8,
         prefetch_buffer_size=1,
         seed=args.seed,
     )
-    dataloader = (jax.make_array_from_process_local_data(videos_sharding, elem) for elem in dataloader) # type: ignore
+    initial_state = grain_dataloader._create_initial_state()
+    grain_iterator = grain.DataLoaderIterator(grain_dataloader, initial_state)
+    
+    # --- Restore checkpoint ---
+    if args.restore_ckpt:
+        abstract_train_state = jax.tree_util.tree_map(ocp.utils.to_shape_dtype_struct, train_state)
+        restored = checkpoint_manager.restore(
+            checkpoint_manager.latest_step(),
+            args=ocp.args.Composite(
+                model_state=ocp.args.StandardRestore(abstract_train_state),
+                dataloader_state=grain.checkpoint.CheckpointRestore(grain_iterator),
+            )
+        )
+        train_state = restored["model_state"]
+        grain_iterator = restored["dataloader_state"]
+        step = checkpoint_manager.latest_step() or 0
+        print(f"Restored dataloader and model state from step {step}")
+
+    # --- TRAIN LOOP ---
+    dataloader = (jax.make_array_from_process_local_data(videos_sharding, elem) for elem in grain_iterator) # type: ignore
     print(f"Starting training from step {step}...")
     while step < args.num_steps:
         for videos in dataloader:
@@ -265,14 +291,17 @@ if __name__ == "__main__":
                             ),
                         )
                         wandb.log(log_images)
-            if step % args.log_checkpoint_interval == 0:
-                ckpt = {"model": train_state}
-                orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
-                save_args = orbax_utils.save_args_from_target(ckpt)
-                orbax_checkpointer.save(
-                    os.path.join(os.getcwd(), args.ckpt_dir, f"tokenizer_{ts}_{step}"),
-                    ckpt,
-                    save_args=save_args,
+            # --- Checkpointing ---
+            if args.save_ckpt and step % args.log_checkpoint_interval == 0:
+                checkpoint_manager.save(
+                    step,
+                    args=ocp.args.Composite(
+                        model_state=ocp.args.StandardSave(train_state),
+                        dataloader_state=grain.checkpoint.CheckpointSave(grain_iterator),
+                    )
                 )
+                print(f"Saved checkpoint at step {step}")
             if step >= args.num_steps:
                 break
+
+    checkpoint_manager.close()

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -197,18 +197,21 @@ if __name__ == "__main__":
         step += int(args.checkpoint.split("_")[-1])
 
     # --- TRAIN LOOP ---
-    tfrecord_files = [
+    array_record_files = [
         os.path.join(args.data_dir, x)
         for x in os.listdir(args.data_dir)
-        if x.endswith(".tfrecord")
+        if x.endswith(".array_record")
     ]
     dataloader = get_dataloader(
         # NOTE: We deliberately pass the global batch size
         # The dataloader shards the dataset across all processes
-        tfrecord_files,
+        array_record_files,
         args.seq_len,
         args.batch_size,
         *image_shape,
+        num_workers=16,
+        prefetch_buffer_size=2,
+        seed=args.seed,
     )
     print(f"Starting training from step {step}...")
     while step < args.num_steps:

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -33,7 +33,7 @@ class Args:
     image_channels: int = 3
     image_height: int = 90
     image_width: int = 160
-    data_dir: str = "data_tfrecords/coinrun"
+    data_dir: str = ""
     checkpoint: str = ""
     # Optimization
     vq_beta: float = 0.25

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -206,7 +206,7 @@ if __name__ == "__main__":
     )
     
     checkpoint_manager = ocp.CheckpointManager(
-        os.path.abspath(args.ckpt_dir),
+        args.ckpt_dir,
         options=checkpoint_options,
         handler_registry=handler_registry,
     )

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -58,6 +58,7 @@ class Args:
     log_image_interval: int = 250
     ckpt_dir: str = ""
     log_checkpoint_interval: int = 10000
+    log_checkpoint_keep_period: int = 20000
     log_gradients: bool = False
 
 
@@ -201,6 +202,7 @@ if __name__ == "__main__":
     checkpoint_options = ocp.CheckpointManagerOptions(
         save_interval_steps=args.log_checkpoint_interval,
         max_to_keep=3,
+        keep_period=args.log_checkpoint_keep_period,
         step_format_fixed_length=6,
         cleanup_tmp_directories=True,
     )

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -1,121 +1,225 @@
-import functools
 import jax
-
+import numpy as np
+import grain
+from typing import Any, Optional
+from array_record.python.array_record_module import ArrayRecordWriter
 import tensorflow as tf
+import os
+from pathlib import Path
+import pickle
+import multiprocessing as mp
+from functools import partial
 
-# reserve GPU memory for JAX only if tensorflow is built with GPU support
-tf.config.experimental.set_visible_devices([], "GPU")
 
 
-# --- TensorFlow function for processing: slicing, normalization ---
-def _tf_process_episode(episode_tensor, seq_len, image_h, image_w, image_c):
+def _convert_single_tfrecord(
+    tfrecord_file: Path,
+    output_folder: str,
+    feature_description: dict,
+) -> str:
     """
-    Processes a raw episode tensor in TensorFlow.
-    Takes a full episode, extracts a random sequence, and normalizes it.
+    Convert a single TFRecord file to ArrayRecord format.
+    
     Args:
-        episode_tensor: A TensorFlow tensor representing a full video episode.
-                        Expected shape: (dynamic_length, image_h, image_w, image_c)
-                        Expected dtype: e.g., tf.uint8 (raw pixel values)
-        seq_len: The desired length of the sub-sequence to extract.
-        image_h: The height of each frame.
-        image_w: The width of each frame.
-        image_c: The number of channels in each frame.
+        tfrecord_file: Path to the TFRecord file
+        output_folder: Output folder for the ArrayRecord file
+        feature_description: Dictionary describing TFRecord features
+    
     Returns:
-        A TensorFlow tensor representing the processed video sequence.
-        Shape: (seq_len, image_h, image_w, image_c)
-        Dtype: tf.float32 (normalized pixel values)
+        Path to the created ArrayRecord file
     """
-    current_episode_len = tf.shape(episode_tensor)[0]
+    output_filename = tfrecord_file.stem + ".array_record"
+    output_file = os.path.join(output_folder, output_filename)
+    
+    dataset = tf.data.TFRecordDataset(str(tfrecord_file))
+    
+    def parse_tfrecord(example_proto):
+        """Parse a single TFRecord example."""
+        parsed_features = tf.io.parse_single_example(example_proto, feature_description)
+        raw_video_bytes = parsed_features['raw_video'].numpy()
+        sequence_length = int(parsed_features['sequence_length'].numpy())
+        
+        return {
+            'raw_video': raw_video_bytes,
+            'sequence_length': sequence_length,
+        }
+    
+    record_count = 0
+    writer = ArrayRecordWriter(output_file, "group_size:1")
+    for record in dataset:
+        parsed_record = parse_tfrecord(record)
+        writer.write(pickle.dumps(parsed_record))
+        record_count += 1
+    writer.close()
+    
+    print(f"Converted {tfrecord_file.name} -> {output_filename}: {record_count} records")
+    return output_file
 
-    max_start_idx = current_episode_len - seq_len
 
-    start_idx = tf.random.uniform(
-        shape=(), minval=0, maxval=max_start_idx + 1, dtype=tf.int32
+def convert_tfrecords_to_arrayrecords(
+    tfrecord_folder: str,
+    output_folder: str,
+    feature_description: Optional[dict] = None,
+    num_workers: Optional[int] = None,
+):
+    """
+    Converts TFRecord files to ArrayRecord format for use with Grain.
+    Creates one ArrayRecord file per TFRecord file using multiprocessing.
+    
+    Args:
+        tfrecord_folder: Path to folder containing TFRecord files
+        output_folder: Path to output folder for ArrayRecord files
+        feature_description: Dictionary describing TFRecord features. If None,
+                           uses default description for video data.
+        num_workers: Number of worker processes. If None, uses CPU count.
+    
+    Returns:
+        List of paths to created ArrayRecord files
+    """
+    if feature_description is None:
+        feature_description = {
+            'raw_video': tf.io.FixedLenFeature([], tf.string),
+            'sequence_length': tf.io.FixedLenFeature([], tf.int64),
+        }
+    
+    os.makedirs(output_folder, exist_ok=True)
+    
+    tfrecord_files = list(Path(tfrecord_folder).glob("*.tfrecord"))
+    if not tfrecord_files:
+        raise ValueError(f"No TFRecord files found in {tfrecord_folder}")
+    
+    print(f"Found {len(tfrecord_files)} TFRecord files")
+    
+    if num_workers is None:
+        num_workers = min(mp.cpu_count(), len(tfrecord_files))
+    
+    print(f"Using {num_workers} worker processes for conversion")
+    
+    convert_func = partial(
+        _convert_single_tfrecord,
+        output_folder=output_folder,
+        feature_description=feature_description
     )
-
-    seq = episode_tensor[start_idx : start_idx + seq_len]
-
-    seq = tf.cast(seq, tf.float32) / 255.0
-
-    # Ensure the final shape is statically known for batching.
-    # tf.reshape is robust, but tf.ensure_shape or set_shape can also be used if confident.
-    processed_sequence = tf.reshape(seq, [seq_len, image_h, image_w, image_c])
-
-    return processed_sequence
+    
+    with mp.Pool(processes=num_workers) as pool:
+        arrayrecord_files = pool.map(convert_func, tfrecord_files)
+    
+    print(f"Conversion complete! Created {len(arrayrecord_files)} ArrayRecord files")
+    return arrayrecord_files
 
 
-def _parse_tfrecord_fn(example_proto, image_h, image_w, image_c):
-    feature_description = {
-        "height": tf.io.FixedLenFeature([], tf.int64),
-        "width": tf.io.FixedLenFeature([], tf.int64),
-        "channels": tf.io.FixedLenFeature([], tf.int64),
-        "sequence_length": tf.io.FixedLenFeature([], tf.int64),
-        "raw_video": tf.io.FixedLenFeature([], tf.string),
-    }
-    example = tf.io.parse_single_example(example_proto, feature_description)
+class ProcessEpisodeAndSlice(grain.transforms.RandomMap):
+    """
+    A Grain Transformation that combines parsing, slicing, and normalizing.
+    """
 
-    video_shape = (example["sequence_length"], image_h, image_w, image_c)
+    def __init__(self, seq_len: int, image_h: int, image_w: int, image_c: int):
+        """Initializes the transformation with processing parameters."""
+        self.seq_len = seq_len
+        self.image_h = image_h
+        self.image_w = image_w
+        self.image_c = image_c
 
-    episode_tensor = tf.io.decode_raw(example["raw_video"], out_type=tf.uint8)
-    episode_tensor = tf.reshape(episode_tensor, video_shape)
+    def random_map(self, element: dict, rng: np.random.Generator) -> Any:
+        """
+        Processes a single raw episode from the data source.
 
-    episode_tensor = tf.ensure_shape(episode_tensor, [None, image_h, image_w, image_c])
-    return episode_tensor
+        Args:
+            element: A dictionary representing one record from the DataSource.
+                     Expected to contain 'raw_video' (bytes) and 'sequence_length' (int)
+            rng: A per-record random number generator provided by the Grain sampler.
+
+        Returns:
+            A processed video sequence as a NumPy array with shape
+            (seq_len, height, width, channels) and dtype float32.
+        """
+        assert isinstance(element, bytes)
+        element = pickle.loads(element)
+        
+        video_shape = (
+            element["sequence_length"],
+            self.image_h,
+            self.image_w,
+            self.image_c,
+        )
+        episode_tensor = np.frombuffer(element["raw_video"], dtype=np.uint8)
+        episode_tensor = episode_tensor.reshape(video_shape)
+
+        current_episode_len = episode_tensor.shape[0]
+        if current_episode_len < self.seq_len:
+             raise ValueError(f"An episode has length {current_episode_len}, which is "
+                              f"shorter than the requested sequence length {self.seq_len}.")
+        
+        max_start_idx = current_episode_len - self.seq_len
+        
+        start_idx = rng.integers(0, max_start_idx + 1)
+
+        seq = episode_tensor[start_idx : start_idx + self.seq_len]
+
+        processed_sequence = seq.astype(np.float32) / 255.0
+
+        return processed_sequence
 
 
 def get_dataloader(
-    tfrecord_paths: list[str],  # List of TFRecord file paths
+    array_record_paths: list[str],
     seq_len: int,
     global_batch_size: int,
     image_h: int,
     image_w: int,
     image_c: int,
-    shuffle_buffer_size: int = 1000,
-    num_parallel_calls: int = tf.data.AUTOTUNE,
+    num_workers: int = 1,
+    prefetch_buffer_size: int = 1,
     seed: int = 42,
 ):
     """
-    Creates a tf.data.Dataset pipeline from TFRecord files.
+    Creates a data loading pipeline using Grain.
     """
-    if not tfrecord_paths:
-        raise ValueError("tfrecord_paths list cannot be empty.")
+    if not array_record_paths:
+        raise ValueError("array_record_paths list cannot be empty.")
 
-    process_id = jax.process_index()
     num_processes = jax.process_count()
 
-    assert (
-        global_batch_size % num_processes == 0
-    ), "Global batch size {global_batch_size} \
-        must be divisible by the number of JAX processes {num_processes} for proper sharding."
+    if global_batch_size % num_processes != 0:
+        raise ValueError(
+            f"Global batch size {global_batch_size} must be divisible by "
+            f"the number of JAX processes {num_processes} for proper sharding."
+        )
     per_process_batch_size = global_batch_size // num_processes
 
-    dataset = tf.data.TFRecordDataset(
-        tfrecord_paths, num_parallel_reads=tf.data.AUTOTUNE
+    source = grain.sources.ArrayRecordDataSource(array_record_paths)
+    
+    sampler = grain.samplers.IndexSampler(
+        num_records=len(source),
+        shard_options=grain.sharding.ShardByJaxProcess(drop_remainder=True),
+        # FIXME: check whether the global shuffle is the reason why the dataloader is so slow
+        shuffle=True,
+        num_epochs=100, # FIXME: is there an equivalent to tf.data.repeat(None)?
+        seed=seed,
     )
 
-    dataset = dataset.shard(num_shards=num_processes, index=process_id)
+    operations = [
+        ProcessEpisodeAndSlice(
+            seq_len=seq_len, image_h=image_h, image_w=image_w, image_c=image_c
+        ),
+        grain.transforms.Batch(batch_size=per_process_batch_size, drop_remainder=True),
+    ]
 
-    # (f.srambical) NOTE: For TFRecords, it's often good to have a large shuffle buffer.
-    if shuffle_buffer_size > 0:
-        dataset = dataset.shuffle(
-            buffer_size=shuffle_buffer_size, seed=seed, reshuffle_each_iteration=True
-        )
-    parse_fn = functools.partial(
-        _parse_tfrecord_fn, image_h=image_h, image_w=image_w, image_c=image_c
+    read_options = grain.ReadOptions(
+        prefetch_buffer_size=prefetch_buffer_size,
+        # FIXME: `If the data is already loaded in memory, we recommend setting this to 0 to
+        # avoid Python GIL contention by multiple threads.`
+        num_threads=1,
     )
-    dataset = dataset.map(parse_fn, num_parallel_calls=num_parallel_calls)
-
-    tf_process_fn = functools.partial(
-        _tf_process_episode,
-        seq_len=seq_len,
-        image_h=image_h,
-        image_w=image_w,
-        image_c=image_c,
+    dataloader = grain.DataLoader(
+        data_source=source,
+        sampler=sampler,
+        operations=operations,
+        worker_count=num_workers,
+        # FIXME: think about whether we should tune this
+        worker_buffer_size=1,
+        read_options=read_options,
     )
-    dataset = dataset.map(tf_process_fn, num_parallel_calls=num_parallel_calls)
 
-    dataset = dataset.repeat(None)
-    dataset = dataset.batch(per_process_batch_size, drop_remainder=True)
-    dataset = dataset.prefetch(tf.data.AUTOTUNE)
+    return iter(dataloader)
 
-    return dataset.as_numpy_iterator()

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -153,5 +153,5 @@ def get_dataloader(
         read_options=read_options,
     )
 
-    return iter(dataloader)
+    return dataloader
 

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -1,0 +1,255 @@
+import os
+import multiprocessing as mp
+import tensorflow as tf
+from typing import Optional
+from array_record.python.array_record_module import ArrayRecordWriter, ArrayRecordReader
+from pathlib import Path
+from functools import partial
+
+tf.config.experimental.set_visible_devices([], "GPU")
+
+def _convert_single_tfrecord(
+    tfrecord_file: Path,
+    output_folder: str,
+    feature_description: dict,
+) -> str:
+    """
+    Convert a single TFRecord file to ArrayRecord format.
+    
+    Args:
+        tfrecord_file: Path to the TFRecord file
+        output_folder: Output folder for the ArrayRecord file
+        feature_description: Dictionary describing TFRecord features
+    
+    Returns:
+        Path to the created ArrayRecord file
+    """
+    output_filename = tfrecord_file.stem + ".array_record"
+    output_file = os.path.join(output_folder, output_filename)
+    
+    dataset = tf.data.TFRecordDataset(str(tfrecord_file))
+    
+    def parse_tfrecord(example_proto):
+        """Parse a single TFRecord example."""
+        parsed_features = tf.io.parse_single_example(example_proto, feature_description)
+        raw_video_bytes = parsed_features['raw_video'].numpy()
+        sequence_length = int(parsed_features['sequence_length'].numpy())
+        
+        return {
+            'raw_video': raw_video_bytes,
+            'sequence_length': sequence_length,
+        }
+    
+    record_count = 0
+    writer = ArrayRecordWriter(output_file, "group_size:1")
+    for record in dataset:
+        parsed_record = parse_tfrecord(record)
+        writer.write(pickle.dumps(parsed_record))
+        record_count += 1
+    writer.close()
+    
+    print(f"Converted {tfrecord_file.name} -> {output_filename}: {record_count} records")
+    return output_file
+
+
+def convert_tfrecords_to_arrayrecords(
+    tfrecord_folder: str,
+    output_folder: str,
+    feature_description: Optional[dict] = None,
+    num_workers: Optional[int] = None,
+):
+    """
+    Converts TFRecord files to ArrayRecord format for use with Grain.
+    Creates one ArrayRecord file per TFRecord file using multiprocessing.
+    
+    Args:
+        tfrecord_folder: Path to folder containing TFRecord files
+        output_folder: Path to output folder for ArrayRecord files
+        feature_description: Dictionary describing TFRecord features. If None,
+                           uses default description for video data.
+        num_workers: Number of worker processes. If None, uses CPU count.
+    
+    Returns:
+        List of paths to created ArrayRecord files
+    """
+    if feature_description is None:
+        feature_description = {
+            'raw_video': tf.io.FixedLenFeature([], tf.string),
+            'sequence_length': tf.io.FixedLenFeature([], tf.int64),
+        }
+    
+    os.makedirs(output_folder, exist_ok=True)
+    
+    tfrecord_files = list(Path(tfrecord_folder).glob("*.tfrecord"))
+    if not tfrecord_files:
+        raise ValueError(f"No TFRecord files found in {tfrecord_folder}")
+    
+    print(f"Found {len(tfrecord_files)} TFRecord files")
+    
+    if num_workers is None:
+        num_workers = min(mp.cpu_count(), len(tfrecord_files))
+    
+    print(f"Using {num_workers} worker processes for conversion")
+    
+    convert_func = partial(
+        _convert_single_tfrecord,
+        output_folder=output_folder,
+        feature_description=feature_description
+    )
+    
+    with mp.Pool(processes=num_workers) as pool:
+        arrayrecord_files = pool.map(convert_func, tfrecord_files)
+    
+    print(f"Conversion complete! Created {len(arrayrecord_files)} ArrayRecord files")
+    return arrayrecord_files
+
+
+def _reprocess_single_arrayrecord(
+    arrayrecord_file: Path,
+    output_folder: str,
+    chunk_size: int,
+    videos_per_file: int,
+    image_h: int,
+    image_w: int,
+    image_c: int,
+    file_index: int,
+) -> list[str]:
+    """
+    Reprocess a single ArrayRecord file by splitting videos into chunks.
+    
+    Args:
+        arrayrecord_file: Path to the ArrayRecord file
+        output_folder: Output folder for the chunked files
+        chunk_size: Number of frames per video chunk
+        videos_per_file: Number of video chunks per output file
+        image_h: Image height in pixels
+        image_w: Image width in pixels
+        image_c: Number of image channels
+        file_index: Index for naming output files
+    
+    Returns:
+        List of paths to created ArrayRecord files
+    """
+    print(f"Processing {arrayrecord_file.name}...")
+    reader = ArrayRecordReader(str(arrayrecord_file))
+    
+    all_record_bytes = reader.read_all()
+    file_chunks = []
+    
+    for record_bytes in all_record_bytes:
+        record = pickle.loads(record_bytes)
+        video_data = record['raw_video']
+        sequence_length = record['sequence_length']
+        
+        video_tensor = np.frombuffer(video_data, dtype=np.uint8)
+        
+        assert video_tensor.shape[0] == sequence_length * image_h * image_w * image_c, \
+            f"Video tensor shape {video_tensor.shape} does not match expected shape {sequence_length * image_h * image_w * image_c}"
+        video_tensor = video_tensor.reshape(sequence_length, image_h, image_w, image_c)
+        
+        current_episode_len = video_tensor.shape[0]
+        if current_episode_len < chunk_size:
+            print(f"Warning: Video has {current_episode_len} frames, skipping (need {chunk_size})")
+            continue
+        
+        for start_idx in range(0, current_episode_len - chunk_size + 1, chunk_size):
+            chunk = video_tensor[start_idx:start_idx + chunk_size]
+            
+            # FIXME: currently no way of correlating the chunk with the original video
+            chunk_record = {
+                'raw_video': chunk.tobytes(),
+                'sequence_length': chunk_size,
+            }
+            
+            file_chunks.append(chunk_record)
+    
+    reader.close()
+    
+    # Write chunks to output files
+    output_files = []
+    for i in range(0, len(file_chunks), videos_per_file):
+        batch_chunks = file_chunks[i:i + videos_per_file]
+        output_filename = f"chunked_videos_{file_index:04d}_{i//videos_per_file:04d}.array_record"
+        output_file = os.path.join(output_folder, output_filename)
+        
+        writer = ArrayRecordWriter(output_file, "group_size:1")
+        for chunk in batch_chunks:
+            writer.write(pickle.dumps(chunk))
+        writer.close()
+        
+        output_files.append(output_file)
+        print(f"Created {output_filename} with {len(batch_chunks)} video chunks")
+    
+    print(f"Processed {arrayrecord_file.name}: {len(file_chunks)} chunks -> {len(output_files)} files")
+    return output_files
+
+
+def reprocess_arrayrecords_to_chunks(
+    arrayrecord_folder: str,
+    output_folder: str,
+    chunk_size: int = 160,
+    videos_per_file: int = 100,
+    image_h: int = 90,
+    image_w: int = 160,
+    image_c: int = 3,
+    num_workers: Optional[int] = None,
+):
+    """
+    Reprocesses ArrayRecord files by splitting videos into chunks and creating new files.
+    
+    This function:
+    1. Reads existing ArrayRecord files in parallel
+    2. Splits each video into chunks of specified size
+    3. Creates new ArrayRecord files with specified number of videos per file
+    
+    Args:
+        arrayrecord_folder: Path to folder containing input ArrayRecord files
+        output_folder: Path to output folder for new ArrayRecord files
+        chunk_size: Number of frames per video chunk (default: 160)
+        videos_per_file: Number of video chunks per output file (default: 100)
+        image_h: Image height in pixels (default: 90)
+        image_w: Image width in pixels (default: 160)
+        image_c: Number of image channels (default: 3 for RGB)
+        num_workers: Number of worker processes. If None, uses CPU count.
+    
+    Returns:
+        List of paths to created ArrayRecord files
+    """
+    os.makedirs(output_folder, exist_ok=True)
+    
+    arrayrecord_files = list(Path(arrayrecord_folder).glob("*.array_record"))
+    if not arrayrecord_files:
+        raise ValueError(f"No ArrayRecord files found in {arrayrecord_folder}")
+    
+    print(f"Found {len(arrayrecord_files)} ArrayRecord files")
+    
+    if num_workers is None:
+        num_workers = min(mp.cpu_count(), len(arrayrecord_files))
+    
+    print(f"Using {num_workers} worker processes for reprocessing")
+    
+    # Create a list of arguments for each file processing task
+    process_args = []
+    for i, file_path in enumerate(arrayrecord_files):
+        process_args.append((
+            file_path,
+            output_folder,
+            chunk_size,
+            videos_per_file,
+            image_h,
+            image_w,
+            image_c,
+            i,
+        ))
+    
+    # Process files in parallel
+    with mp.Pool(processes=num_workers) as pool:
+        results = pool.starmap(_reprocess_single_arrayrecord, process_args)
+    
+    # Flatten the results
+    all_output_files = []
+    for result in results:
+        all_output_files.extend(result)
+    
+    print(f"Reprocessing complete! Created {len(all_output_files)} new ArrayRecord files")
+    return all_output_files


### PR DESCRIPTION
- switched dataloader to grain
- dataloader is now fully independent of `tenorflow`/`tf.data`
- switched dataset format to [array_records](https://github.com/google/array_record), which is optimized for parallel random access
- to be fully compute-bound when the dataset is on GPFS, we have to split the videos into 16s (160 frame) chunks (like genie does), and have ~100 records per array_record
  - added utilities for this & conversion from `tfrecord` to `array_record`
- tested on knoms