### PR TITLE
Speedup and fix autoreg sampling

### DIFF
--- a/genie.py
+++ b/genie.py
@@ -130,10 +130,10 @@ class Genie(nn.Module):
         for step_t in range(T, seq_len):
             print(f"Sampling Frame {step_t}...")
             # mask current and future frames (i.e., t >= step_t)
-            mask = jnp.arange(seq_len) < step_t # (S,)
+            mask = jnp.arange(seq_len) >= step_t # (S,)
             mask = jnp.broadcast_to(mask[None, :, None], (B, seq_len, N)) # (B, S, N)
             mask = mask.astype(bool)
-            token_idxs *= mask
+            token_idxs *= ~mask
 
             # --- Initialize MaskGIT ---
             init_carry = (
@@ -186,7 +186,7 @@ class MaskGITStep(nn.Module):
     def __call__(self, carry, x):
         rng, token_idxs, mask, action_tokens = carry
         step = x
-        _, _, N = token_idxs.shape[:3]
+        N = token_idxs.shape[2]
 
         # --- Construct + encode video ---
         vid_embed = self.dynamics.patch_embed(token_idxs) # (B, S, N, D)

--- a/genie.py
+++ b/genie.py
@@ -97,20 +97,25 @@ class Genie(nn.Module):
         sample_argmax: bool = False,
     ) -> Any:
         """
-        Autoregressively samples up to `seq_len` frames, as in Figure 8 of the paper.
+        Autoregressively samples up to `seq_len` future frames, following Figure 8 of the paper.
 
-        Input frames are tokenized once, new frames are autoregressively generated in token space and all are detokenized in a single pass.
-        For stepwise interactive sampling, detokenization would need to occur after each action.
+        - Input frames are tokenized once.
+        - Future frames are generated autoregressively in token space.
+        - All frames are detokenized in a single pass.
 
-        Note, we decode all (current and future) frames each step to maintain tensor shapes. 
-        By reapplying the mask before each decoding step we don't hurt the temporal causal structure. 
+        Note:
+        - For interactive or stepwise sampling, detokenization should occur after each action.
+        - To maintain consistent tensor shapes across timesteps, all current and future frames are decoded at every step.
+        - Temporal causal structure is preserved by 
+            a) reapplying the mask before each decoding step.
+            b) a temporal causal mask is applied within each ST-transformer block.
 
         Dimension keys:
-            B: batch size
-            T: number of input (conditioning) frames
-            N: patches per frame
-            S: sequence length
-            A: action space
+            B: batch size  
+            T: number of input (conditioning) frames  
+            N: patches per frame  
+            S: sequence length  
+            A: action space  
             D: model latent dimension
         """
         # --- Encode videos and actions ---


### PR DESCRIPTION
## Autoregressively samples up to `seq_len` future frames, following Figure 8 of the paper
- Input frames are tokenized 
- Future frames are generated autoregressively in token space
- All frames are detokenized in a single pass.

- speeds up sampling by 4x and increases reconstruction quality significantly (distribution shift between training and inference is lower)


Note:

- For interactive or stepwise sampling, detokenization should occur after each action.
- maintain consistent tensor shapes across timesteps, all current and future frames are decoded at every step.
- causal structure is preserved by 
  1. reapplying the mask before each decoding step.
  2. a temporal causal mask is applied within each ST-transformer block.


![image](https://github.com/user-attachments/assets/f8c0b046-4ee8-4e77-937b-c183acb3693d)
