### PR TITLE
fix: remove ts from checkpointing dir to avoid deadlock

### DIFF
--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 import os
-import time
 
 import einops
 from flax.training import orbax_utils
@@ -21,8 +20,6 @@ from models.tokenizer import TokenizerVQVAE
 from models.lam import LatentActionModel
 from utils.dataloader import get_dataloader
 from utils.parameter_utils import count_parameters_by_component
-
-ts = int(time.time())
 
 
 @dataclass
@@ -272,7 +269,7 @@ if __name__ == "__main__":
                 orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
                 save_args = orbax_utils.save_args_from_target(ckpt)
                 orbax_checkpointer.save(
-                    os.path.join(os.getcwd(), args.ckpt_dir, f"genie_{ts}_{step}"),
+                    os.path.join(os.getcwd(), args.ckpt_dir, f"genie_{step}"),
                     ckpt,
                     save_args=save_args,
                 )

--- a/train_lam.py
+++ b/train_lam.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 import os
-import time
 
 import einops
 from flax.training import orbax_utils
@@ -20,8 +19,6 @@ import wandb
 from models.lam import LatentActionModel
 from utils.dataloader import get_dataloader
 from utils.parameter_utils import count_parameters_by_component
-
-ts = int(time.time())
 
 
 @dataclass
@@ -273,7 +270,7 @@ if __name__ == "__main__":
                 orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
                 save_args = orbax_utils.save_args_from_target(ckpt)
                 orbax_checkpointer.save(
-                    os.path.join(os.getcwd(), args.ckpt_dir, f"lam_{ts}_{step}"),
+                    os.path.join(os.getcwd(), args.ckpt_dir, f"lam_{step}"),
                     ckpt,
                     save_args=save_args,
                 )

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 import os
-import time
 
 import einops
 from flax.training import orbax_utils
@@ -20,8 +19,6 @@ import wandb
 from models.tokenizer import TokenizerVQVAE
 from utils.dataloader import get_dataloader
 from utils.parameter_utils import count_parameters_by_component
-
-ts = int(time.time())
 
 
 @dataclass
@@ -268,7 +265,7 @@ if __name__ == "__main__":
                 orbax_checkpointer = orbax.checkpoint.PyTreeCheckpointer()
                 save_args = orbax_utils.save_args_from_target(ckpt)
                 orbax_checkpointer.save(
-                    os.path.join(os.getcwd(), args.ckpt_dir, f"tokenizer_{ts}_{step}"),
+                    os.path.join(os.getcwd(), args.ckpt_dir, f"tokenizer_{step}"),
                     ckpt,
                     save_args=save_args,
                 )


### PR DESCRIPTION
- Previously, the checkpointing directory contained the timestamp of the start of the python process
- However, with increasing number of processes, the likelihood of not all python processes starting the same second increases
- The moment a single process has a different starting timestamp, that process will try to checkpoint into a different directory and all other processes will indefinitely wait for that one process during orbax checkpointing