### PR TITLE
revert: partial remat

### DIFF
--- a/utils/nn.py
+++ b/utils/nn.py
@@ -37,7 +37,7 @@ class STBlock(nn.Module):
     dtype: jnp.dtype
     use_flash_attention: bool
 
-    @partial(nn.remat, policy=jax.checkpoint_policies.checkpoint_dots_with_no_batch_dims)
+    @nn.remat
     @nn.compact
     def __call__(self, x: jax.Array) -> jax.Array:
         # --- Spatial attention ---


### PR DESCRIPTION
Partial remat does not lead to an increase in throughput when used with larger `ffn_dim`. As such, we should revert that change if we are to merge https://github.com/p-doom/jafar/pull/90 since full remat means that more HBM stays free (which will be useful when we scale the model).