### PR TITLE
chore: infer dtype type annotation (fix warning)

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -50,8 +50,8 @@ class Args:
     dyna_dim: int = 512
     dyna_num_blocks: int = 12
     dyna_num_heads: int = 8
-    param_dtype: jnp.dtype = jnp.float32
-    dtype: jnp.dtype = jnp.bfloat16
+    param_dtype = jnp.float32
+    dtype = jnp.bfloat16
     use_flash_attention: bool = True
 
 

--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -62,8 +62,8 @@ class Args:
     dyna_num_heads: int = 8
     dropout: float = 0.0
     mask_limit: float = 0.5
-    param_dtype: jnp.dtype = jnp.float32
-    dtype: jnp.dtype = jnp.bfloat16
+    param_dtype = jnp.float32
+    dtype = jnp.bfloat16
     use_flash_attention: bool = True
     # Logging
     log: bool = False

--- a/train_lam.py
+++ b/train_lam.py
@@ -53,8 +53,8 @@ class Args:
     num_heads: int = 8
     dropout: float = 0.0
     codebook_dropout: float = 0.0
-    param_dtype: jnp.dtype = jnp.float32
-    dtype: jnp.dtype = jnp.bfloat16
+    param_dtype = jnp.float32
+    dtype = jnp.bfloat16
     # Logging
     log: bool = False
     entity: str = ""

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -52,8 +52,8 @@ class Args:
     num_heads: int = 8
     dropout: float = 0.0
     codebook_dropout: float = 0.01
-    param_dtype: jnp.dtype = jnp.float32
-    dtype: jnp.dtype = jnp.bfloat16
+    param_dtype = jnp.float32
+    dtype = jnp.bfloat16
     # Logging
     log: bool = False
     entity: str = ""


### PR DESCRIPTION
- Gets rid of the warning:
```UserWarning: The field `dtype` is annotated with type `<class 'numpy.dtype'>`, but the default value `<class 'jax.numpy.bfloat16'>` has type `<class 'jax._src.numpy.scalar_types._ScalarMeta'>`. We'll try to handle this gracefully, but it may cause unexpected behavior.```