### PR TITLE
feat: different maskprob per sample for maskgit training

### DIFF
--- a/models/dynamics.py
+++ b/models/dynamics.py
@@ -58,7 +58,7 @@ class DynamicsMaskGIT(nn.Module):
             mask = jax.vmap(
                 lambda rng, prob: jax.random.bernoulli(rng, prob, per_sample_shape),
                 in_axes=(0, 0),
-            )(_rngs_mask, mask_prob)
+            )(jnp.asarray(_rngs_mask), mask_prob)
             mask = mask.at[:, 0].set(False)
             vid_embed = jnp.where(jnp.expand_dims(mask, -1), self.mask_token, vid_embed)
         else:

--- a/models/dynamics.py
+++ b/models/dynamics.py
@@ -56,13 +56,11 @@ class DynamicsMaskGIT(nn.Module):
             )
             mask_rngs = jax.random.split(rng2, batch_size)
 
-            def sample_mask(rng, prob, shape):
-                return jax.random.bernoulli(rng, prob, shape)
-
             per_sample_shape = vid_embed.shape[1:-1]
-            mask = jax.vmap(sample_mask, in_axes=(0, 0, None))(
-                mask_rngs, mask_prob, per_sample_shape
-            )
+            mask = jax.vmap(
+                lambda rng, prob: jax.random.bernoulli(rng, prob, per_sample_shape),
+                in_axes=(0, 0)
+            )(mask_rngs, mask_prob)
             mask = mask.at[:, 0].set(False)
             vid_embed = jnp.where(jnp.expand_dims(mask, -1), self.mask_token, vid_embed)
         else:

--- a/models/dynamics.py
+++ b/models/dynamics.py
@@ -55,11 +55,10 @@ class DynamicsMaskGIT(nn.Module):
                 rng1, shape=(batch_size,), minval=self.mask_limit
             )
             mask_rngs = jax.random.split(rng2, batch_size)
-
             per_sample_shape = vid_embed.shape[1:-1]
             mask = jax.vmap(
                 lambda rng, prob: jax.random.bernoulli(rng, prob, per_sample_shape),
-                in_axes=(0, 0)
+                in_axes=(0, 0),
             )(mask_rngs, mask_prob)
             mask = mask.at[:, 0].set(False)
             vid_embed = jnp.where(jnp.expand_dims(mask, -1), self.mask_token, vid_embed)


### PR DESCRIPTION
credits @avocadoali for noticing this.

results in far lower variance:
<img width="1286" height="842" alt="image" src="https://github.com/user-attachments/assets/895e8071-afc4-47af-ae48-c33c130053ef" />
